### PR TITLE
feat(mentor): 멘토 조회 API 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/app/sigorotalk/backend/domain/mentor/Mentor.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/Mentor.java
@@ -4,9 +4,7 @@ package app.sigorotalk.backend.domain.mentor;
 import app.sigorotalk.backend.common.entity.BaseTimeEntity;
 import app.sigorotalk.backend.domain.user.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 
@@ -14,6 +12,8 @@ import java.math.BigDecimal;
 @Table(name = "tb_mentor")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
 public class Mentor extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/MentorController.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/MentorController.java
@@ -1,14 +1,33 @@
 package app.sigorotalk.backend.domain.mentor;
 
+import app.sigorotalk.backend.common.response.ApiResponse;
+import app.sigorotalk.backend.domain.mentor.dto.MentorDetailResponseDto;
+import app.sigorotalk.backend.domain.mentor.dto.MentorListResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/mentors")
+@RequiredArgsConstructor
 public class MentorController {
 
-    // TODO: [GET /] 멘토 목록 조회 API (페이징, 정렬)
+    private final MentorService mentorService;
 
-    // TODO: [GET /{mentorId}] 멘토 상세 조회 API
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<MentorListResponseDto>>> getMentorList(Pageable pageable) {
+        Page<MentorListResponseDto> mentorList = mentorService.getMentorList(pageable);
+        return ResponseEntity.ok(ApiResponse.success(mentorList));
+    }
 
+    @GetMapping("/{mentorId}")
+    public ResponseEntity<ApiResponse<MentorDetailResponseDto>> getMentorDetail(@PathVariable Long mentorId) {
+        MentorDetailResponseDto mentorDetail = mentorService.getMentorDetail(mentorId);
+        return ResponseEntity.ok(ApiResponse.success(mentorDetail));
+    }
 }

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/MentorController.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/MentorController.java
@@ -26,7 +26,7 @@ public class MentorController {
     }
 
     @GetMapping("/{mentorId}")
-    public ResponseEntity<ApiResponse<MentorDetailResponseDto>> getMentorDetail(@PathVariable Long mentorId) {
+    public ResponseEntity<ApiResponse<MentorDetailResponseDto>> getMentorDetail(@PathVariable("mentorId") Long mentorId) {
         MentorDetailResponseDto mentorDetail = mentorService.getMentorDetail(mentorId);
         return ResponseEntity.ok(ApiResponse.success(mentorDetail));
     }

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/MentorRepository.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/MentorRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
 
     // 멘토 목록 조회 시 N+1 문제 해결을 위해 User를 fetch join
-    @Query(value = "SELECT m FROM Mentor m JOIN FETCH m.user",
+    @Query(value = "SELECT m FROM Mentor m JOIN FETCH m.user ORDER BY m.id",
             countQuery = "SELECT COUNT(m) FROM Mentor m")
     Page<Mentor> findAllWithUser(Pageable pageable);
 

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/MentorRepository.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/MentorRepository.java
@@ -1,6 +1,22 @@
 package app.sigorotalk.backend.domain.mentor;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
+
+    // 멘토 목록 조회 시 N+1 문제 해결을 위해 User를 fetch join
+    @Query(value = "SELECT m FROM Mentor m JOIN FETCH m.user",
+            countQuery = "SELECT COUNT(m) FROM Mentor m")
+    Page<Mentor> findAllWithUser(Pageable pageable);
+
+    // 멘토 상세 조회 시 User를 fetch join
+    @Query("SELECT m FROM Mentor m JOIN FETCH m.user WHERE m.id = :mentorId")
+    Optional<Mentor> findByIdWithUser(@Param("mentorId") Long mentorId);
+
 }

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/MentorService.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/MentorService.java
@@ -1,13 +1,42 @@
 package app.sigorotalk.backend.domain.mentor;
 
+import app.sigorotalk.backend.common.exception.BusinessException;
+import app.sigorotalk.backend.common.exception.CommonErrorCode;
+import app.sigorotalk.backend.domain.mentor.dto.MentorDetailResponseDto;
+import app.sigorotalk.backend.domain.mentor.dto.MentorListResponseDto;
+import app.sigorotalk.backend.domain.review.Review;
+import app.sigorotalk.backend.domain.review.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MentorService {
 
-    // TODO: 멘토 목록 조회 로직 구현 (페이징, 정렬 포함)
+    private final MentorRepository mentorRepository;
+    private final ReviewRepository reviewRepository;
 
-    // TODO: 멘토 상세 조회 로직 구현
+    public Page<MentorListResponseDto> getMentorList(Pageable pageable) {
+        // TODO: 필터링 기능 추가 (region, expertise 등)
+        return mentorRepository.findAll(pageable)
+                .map(MentorListResponseDto::from);
+    }
+
+    public MentorDetailResponseDto getMentorDetail(Long mentorId) {
+        Mentor mentor = mentorRepository.findById(mentorId)
+                .orElseThrow(() -> new BusinessException(CommonErrorCode.NOT_FOUND));
+
+        // 멘토의 리뷰 목록 조회
+        List<Review> reviews = reviewRepository.findByCoffeeChatApplication_Mentor_Id(mentorId);
+
+        return MentorDetailResponseDto.from(mentor, reviews);
+    }
 
     // TODO: (관리자용) 멘토 등록 로직 구현
 

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/MentorService.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/MentorService.java
@@ -24,12 +24,12 @@ public class MentorService {
 
     public Page<MentorListResponseDto> getMentorList(Pageable pageable) {
         // TODO: 필터링 기능 추가 (region, expertise 등)
-        return mentorRepository.findAll(pageable)
+        return mentorRepository.findAllWithUser(pageable)
                 .map(MentorListResponseDto::from);
     }
 
     public MentorDetailResponseDto getMentorDetail(Long mentorId) {
-        Mentor mentor = mentorRepository.findById(mentorId)
+        Mentor mentor = mentorRepository.findByIdWithUser(mentorId)
                 .orElseThrow(() -> new BusinessException(CommonErrorCode.NOT_FOUND));
 
         // 멘토의 리뷰 목록 조회

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/dto/MentorDetailResponseDto.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/dto/MentorDetailResponseDto.java
@@ -1,0 +1,52 @@
+package app.sigorotalk.backend.domain.mentor.dto;
+
+import app.sigorotalk.backend.domain.mentor.Mentor;
+import app.sigorotalk.backend.domain.review.Review;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class MentorDetailResponseDto {
+
+    private final Long mentorId;
+    private final String name;
+    private final String profileImageUrl;
+    private final String expertise;
+    private final String region;
+    private final String shortDescription;
+    private final String detailedDescription;
+    private final String career;
+    private final BigDecimal averageRating;
+    private final List<ReviewDto> reviews;
+
+    @Getter
+        @Builder
+        private record ReviewDto(Integer rating, String comment) {
+            static ReviewDto from(Review review) {
+                return ReviewDto.builder()
+                        .rating(review.getRating())
+                        .comment(review.getComment())
+                        .build();
+            }
+        }
+
+    public static MentorDetailResponseDto from(Mentor mentor, List<Review> reviews) {
+        return MentorDetailResponseDto.builder()
+                .mentorId(mentor.getId())
+                .name(mentor.getUser().getName())
+                .profileImageUrl(mentor.getProfileImageUrl())
+                .expertise(mentor.getExpertise())
+                .region(mentor.getRegion())
+                .shortDescription(mentor.getShortDescription())
+                .detailedDescription(mentor.getDetailedDescription())
+                .career(mentor.getCareer())
+                .averageRating(mentor.getAverageRating())
+                .reviews(reviews.stream().map(ReviewDto::from).collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/dto/MentorDetailResponseDto.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/dto/MentorDetailResponseDto.java
@@ -24,17 +24,6 @@ public class MentorDetailResponseDto {
     private final BigDecimal averageRating;
     private final List<ReviewDto> reviews;
 
-    @Getter
-        @Builder
-        private record ReviewDto(Integer rating, String comment) {
-            static ReviewDto from(Review review) {
-                return ReviewDto.builder()
-                        .rating(review.getRating())
-                        .comment(review.getComment())
-                        .build();
-            }
-        }
-
     public static MentorDetailResponseDto from(Mentor mentor, List<Review> reviews) {
         return MentorDetailResponseDto.builder()
                 .mentorId(mentor.getId())
@@ -48,5 +37,19 @@ public class MentorDetailResponseDto {
                 .averageRating(mentor.getAverageRating())
                 .reviews(reviews.stream().map(ReviewDto::from).collect(Collectors.toList()))
                 .build();
+    }
+
+    @Getter
+    @Builder
+    private static class ReviewDto { // private record -> private static class
+        private final Integer rating;
+        private final String comment;
+
+        static ReviewDto from(Review review) {
+            return ReviewDto.builder()
+                    .rating(review.getRating())
+                    .comment(review.getComment())
+                    .build();
+        }
     }
 }

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/dto/MentorListResponseDto.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/dto/MentorListResponseDto.java
@@ -1,0 +1,33 @@
+package app.sigorotalk.backend.domain.mentor.dto;
+
+import app.sigorotalk.backend.domain.mentor.Mentor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class MentorListResponseDto {
+    private final Long mentorId;
+    private final String name;
+    private final String profileImageUrl;
+    private final String expertise;
+    private final String region;
+    private final String shortDescription;
+    private final BigDecimal averageRating;
+    private final Integer reviewCount;
+
+    public static MentorListResponseDto from(Mentor mentor) {
+        return MentorListResponseDto.builder()
+                .mentorId(mentor.getId())
+                .name(mentor.getUser().getName()) // User 엔티티에서 이름 가져오기
+                .profileImageUrl(mentor.getProfileImageUrl())
+                .expertise(mentor.getExpertise())
+                .region(mentor.getRegion())
+                .shortDescription(mentor.getShortDescription())
+                .averageRating(mentor.getAverageRating())
+                .reviewCount(mentor.getReviewCount())
+                .build();
+    }
+}

--- a/src/main/java/app/sigorotalk/backend/domain/review/ReviewRepository.java
+++ b/src/main/java/app/sigorotalk/backend/domain/review/ReviewRepository.java
@@ -2,5 +2,10 @@ package app.sigorotalk.backend.domain.review;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    // 특정 커피챗 신청(application_id)에 연결된 리뷰 찾기
+    List<Review> findByCoffeeChatApplication_Mentor_Id(Long mentorId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,3 +36,8 @@ management:
 logging:
   level:
     root: INFO
+
+jwt:
+  secret: V2VMa2VTaWdvcm90YWxrQW5kSXRzQmVzdG9mQmVzdFNlY3JldEtleUZvclByb2plY3Q= # <-- 64바이트 이상의 Base64 인코딩된 문자열
+  access-token-validity-in-seconds: 86400 # 24시간
+  refresh-token-validity-in-seconds: 604800 # 7일

--- a/src/test/java/app/sigorotalk/backend/config/mentor/MentorControllerTest.java
+++ b/src/test/java/app/sigorotalk/backend/config/mentor/MentorControllerTest.java
@@ -1,0 +1,102 @@
+package app.sigorotalk.backend.config.mentor;
+
+import app.sigorotalk.backend.domain.mentor.Mentor;
+import app.sigorotalk.backend.domain.mentor.MentorRepository;
+import app.sigorotalk.backend.domain.user.User;
+import app.sigorotalk.backend.domain.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class MentorControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MentorRepository mentorRepository;
+
+    private Mentor savedMentor;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 데이터 생성
+        User testUser = User.builder()
+                .email("mentor@example.com")
+                .password("password")
+                .name("테스트멘토")
+                .role(User.Role.ROLE_MENTOR)
+                .build();
+        userRepository.save(testUser);
+
+        savedMentor = Mentor.builder()
+                .user(testUser)
+                .shortDescription("테스트 짧은 설명")
+                .expertise("Java, Spring")
+                .build();
+        mentorRepository.save(savedMentor);
+    }
+
+    @Test
+    @DisplayName("멘토 목록 조회 API 성공: 200 OK와 함께 페이징된 데이터를 반환한다.")
+    @WithMockUser
+        // 인증된 사용자로 간주
+    void getMentorListApi_Success() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/mentors")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.response.content[0].name").value("테스트멘토"))
+                .andExpect(jsonPath("$.response.content[0].expertise").value("Java, Spring"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("멘토 상세 조회 API 성공: 200 OK와 함께 상세 데이터를 반환한다.")
+    @WithMockUser
+    void getMentorDetailApi_Success() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/mentors/" + savedMentor.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.response.mentorId").value(savedMentor.getId()))
+                .andExpect(jsonPath("$.response.name").value("테스트멘토"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("멘토 상세 조회 API 실패: 존재하지 않는 ID 요청 시 404 Not Found를 반환한다.")
+    @WithMockUser
+    void getMentorDetailApi_Failure_NotFound() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/mentors/9999")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.message").value("요청한 리소스를 찾을 수 없습니다."))
+                .andDo(print());
+    }
+}

--- a/src/test/java/app/sigorotalk/backend/config/mentor/MentorServiceTest.java
+++ b/src/test/java/app/sigorotalk/backend/config/mentor/MentorServiceTest.java
@@ -1,0 +1,92 @@
+package app.sigorotalk.backend.config.mentor;
+
+import app.sigorotalk.backend.common.exception.BusinessException;
+import app.sigorotalk.backend.domain.mentor.Mentor;
+import app.sigorotalk.backend.domain.mentor.MentorRepository;
+import app.sigorotalk.backend.domain.mentor.MentorService;
+import app.sigorotalk.backend.domain.review.Review;
+import app.sigorotalk.backend.domain.review.ReviewRepository;
+import app.sigorotalk.backend.domain.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MentorServiceTest {
+
+    @InjectMocks
+    private MentorService mentorService;
+
+    @Mock
+    private MentorRepository mentorRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Test
+    @DisplayName("멘토 목록 조회 성공: 페이징된 멘토 목록을 DTO로 변환하여 반환한다.")
+    void getMentorList_Success() {
+        // given
+        User testUser = User.builder().name("테스트 멘토").build();
+        Mentor testMentor = Mentor.builder().user(testUser).build();
+        Page<Mentor> mentorPage = new PageImpl<>(Collections.singletonList(testMentor));
+        Pageable pageable = PageRequest.of(0, 10);
+
+        when(mentorRepository.findAllWithUser(any(Pageable.class))).thenReturn(mentorPage);
+
+        // when
+        var result = mentorService.getMentorList(pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getName()).isEqualTo("테스트 멘토");
+    }
+
+    @Test
+    @DisplayName("멘토 상세 조회 성공: 멘토 정보와 리뷰 목록을 포함한 DTO를 반환한다.")
+    void getMentorDetail_Success() {
+        // given
+        User testUser = User.builder().name("상세조회 멘토").build();
+        Mentor testMentor = Mentor.builder().id(1L).user(testUser).build();
+        List<Review> reviews = Collections.emptyList();
+
+        when(mentorRepository.findByIdWithUser(1L)).thenReturn(Optional.of(testMentor));
+        when(reviewRepository.findByCoffeeChatApplication_Mentor_Id(1L)).thenReturn(reviews);
+
+        // when
+        var result = mentorService.getMentorDetail(1L);
+
+        // then
+        assertThat(result.getMentorId()).isEqualTo(1L);
+        assertThat(result.getName()).isEqualTo("상세조회 멘토");
+        assertThat(result.getReviews()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("멘토 상세 조회 실패: 존재하지 않는 ID로 조회 시 BusinessException 발생")
+    void getMentorDetail_Failure_NotFound() {
+        // given
+        when(mentorRepository.findByIdWithUser(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> mentorService.getMentorDetail(999L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("요청한 리소스를 찾을 수 없습니다.");
+    }
+}


### PR DESCRIPTION
MVP 1차 명세에 따라, 서비스의 핵심 도메인 중 하나인 **멘토 조회 기능**을 구현하고 관련 테스트 코드를 작성했습니다. 이 PR을 통해 사용자는 멘토 목록을 탐색하고, 특정 멘토의 상세 정보를 확인할 수 있는 API를 사용할 수 있게 됩니다.

---

#### **2. 상세 작업 내용 ✨**

이번 PR은 아래 세 가지 주요 작업을 포함합니다.

- **`feat`: 멘토 조회 API 구현**
    
    - `GET /api/v1/mentors`: 멘토 목록을 페이징하여 조회하는 API를 구현했습니다.
        
    - `GET /api/v1/mentors/{mentorId}`: 특정 멘토의 상세 정보(리뷰 포함)를 조회하는 API를 구현했습니다.
        
    - `MentorListResponseDto`, `MentorDetailResponseDto` 등 API 명세에 맞는 응답 DTO를 설계했습니다.
        
- **`refactor`: 성능 최적화**
    
    - `User` 엔티티와의 연관관계에서 발생할 수 있는 **N+1 문제를 `fetch join`을 적용하여 해결**했습니다. 이를 통해 불필요한 추가 쿼리를 제거하고 API 응답 성능을 개선했습니다.
        
- **`test` & `fix`: 테스트 작성 및 버그 수정**
    
    - `MentorService`에 대한 **단위 테스트**와 `MentorController`에 대한 **통합 테스트**를 작성하여 기능의 안정성과 정확성을 확보했습니다.
        
    - 테스트 과정에서 발견된 아래 버그들을 수정했습니다.
        
        - `Mentor` 엔티티: 테스트 객체 생성을 위한 `@Builder`, `@AllArgsConstructor` 추가
            
        - `MentorDetailResponseDto`: Lombok 호환성을 위해 내부 `ReviewDto`를 `record`에서 `static class`로 변경
            
        - `MentorController`: `@PathVariable` 이름 누락으로 인한 런타임 에러 해결
            

---

#### **3. 제외된 기능 및 향후 계획 (Limitations & Future Work) ⚠️**

이번 PR은 멘토 조회 기능의 핵심 골격을 완성하는 데 집중했으며, 아래 기능은 **포함되지 않았습니다.**

- **멘토 목록 필터링**: `지역(region)`, `전문 분야(expertise)` 등 동적 조건에 따른 필터링 기능은 `TODO`로 남겨두었습니다. 이는 `QueryDSL` 도입과 함께 다음 단계에서 구현할 예정입니다.
    
- **멘토 평점/리뷰 수 업데이트**: 해당 로직은 '리뷰 작성' 기능 구현 시 연동되어야 하므로, 리뷰 도메인 개발 시 함께 구현할 예정입니다.
    

---

#### **4. 리뷰 요청 사항 🙏**

- 구현된 API가 명세서의 요구사항을 모두 충족하는지 확인 부탁드립니다.
    
- N+1 문제 해결을 위해 적용한 `fetch join` 쿼리가 적절한지 검토 부탁드립니다.
    
- 작성된 테스트 코드가 핵심 성공/실패 케이스를 충분히 커버하고 있는지 리뷰해주시면 감사하겠습니다.