### PR TITLE
feat(coffeechat): 커피챗 기능 구현 및 전체 테스트 코드 작성

### DIFF
--- a/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatApplication.java
+++ b/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatApplication.java
@@ -1,12 +1,11 @@
 package app.sigorotalk.backend.domain.coffeechat;
 
 import app.sigorotalk.backend.common.entity.BaseTimeEntity;
+import app.sigorotalk.backend.common.exception.BusinessException;
 import app.sigorotalk.backend.domain.mentor.Mentor;
 import app.sigorotalk.backend.domain.user.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -15,6 +14,8 @@ import java.time.LocalDateTime;
 @Table(name = "tb_coffee_chat_application")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class CoffeeChatApplication extends BaseTimeEntity {
 
     @Id
@@ -36,7 +37,61 @@ public class CoffeeChatApplication extends BaseTimeEntity {
 
     private LocalDateTime applicationDate;
 
-    private LocalDateTime chatDate;
+    private LocalDateTime acceptedAt;
+
+    /**
+     * 멘토가 커피챗 신청을 수락합니다.
+     *
+     * @param mentorUser 요청한 사용자 (반드시 멘토여야 함)
+     */
+    public void accept(User mentorUser) {
+        // 1. 권한 검증: 요청자가 이 커피챗의 멘토인지 확인
+        if (!this.getMentor().getUser().getId().equals(mentorUser.getId())) {
+            throw new BusinessException(CoffeeChatErrorCode.NO_AUTHORITY_TO_UPDATE_STATUS);
+        }
+        // 2. 상태 검증: 현재 상태가 PENDING일 때만 수락 가능
+        if (this.status != Status.PENDING) {
+            throw new BusinessException(CoffeeChatErrorCode.CANNOT_CHANGE_STATUS);
+        }
+        // 3. 상태 변경
+        this.status = Status.ACCEPTED;
+        this.acceptedAt = LocalDateTime.now(); // 수락 시간 기록
+    }
+
+    // --- 비즈니스 로직을 엔티티로 이전 ---
+
+    /**
+     * 멘토가 커피챗 신청을 거절합니다.
+     *
+     * @param mentorUser 요청한 사용자 (반드시 멘토여야 함)
+     */
+    public void reject(User mentorUser) {
+        if (!this.getMentor().getUser().getId().equals(mentorUser.getId())) {
+            throw new BusinessException(CoffeeChatErrorCode.NO_AUTHORITY_TO_UPDATE_STATUS);
+        }
+        if (this.status != Status.PENDING) {
+            throw new BusinessException(CoffeeChatErrorCode.CANNOT_CHANGE_STATUS);
+        }
+        this.status = Status.REJECTED;
+    }
+
+    /**
+     * 멘티가 커피챗을 완료 처리합니다.
+     *
+     * @param menteeUser 요청한 사용자 (반드시 멘티여야 함)
+     */
+    public void complete(User menteeUser) {
+        // 1. 권한 검증: 요청자가 이 커피챗의 멘티인지 확인
+        if (!this.getMentee().getId().equals(menteeUser.getId())) {
+            throw new BusinessException(CoffeeChatErrorCode.NO_AUTHORITY_TO_UPDATE_STATUS);
+        }
+        // 2. 상태 검증: 수락(ACCEPTED) 상태의 커피챗만 완료 처리 가능
+        if (this.status != Status.ACCEPTED) {
+            throw new BusinessException(CoffeeChatErrorCode.INVALID_STATUS_FOR_COMPLETION);
+        }
+        // 3. 상태 변경
+        this.status = Status.COMPLETED;
+    }
 
     public enum Status {
         PENDING, ACCEPTED, REJECTED, COMPLETED

--- a/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatApplicationRepository.java
+++ b/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatApplicationRepository.java
@@ -2,6 +2,19 @@ package app.sigorotalk.backend.domain.coffeechat;
 
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CoffeeChatApplicationRepository extends JpaRepository<CoffeeChatApplication, Long> {
+
+    // 특정 사용자가 멘티 또는 멘토로 속한 모든 커피챗 목록을 조회 (N+1 문제 해결을 위해 fetch join 사용)
+    @Query("SELECT ca FROM CoffeeChatApplication ca " +
+            "JOIN FETCH ca.mentee " +
+            "JOIN FETCH ca.mentor m " +
+            "JOIN FETCH m.user " +
+            "WHERE ca.mentee.id = :userId OR m.user.id = :userId " +
+            "ORDER BY ca.applicationDate DESC")
+    List<CoffeeChatApplication> findMyChatsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatController.java
+++ b/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatController.java
@@ -1,26 +1,73 @@
 package app.sigorotalk.backend.domain.coffeechat;
 
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import app.sigorotalk.backend.common.response.ApiResponse;
+import app.sigorotalk.backend.domain.coffeechat.dto.ChatStatusUpdateResponseDto;
+import app.sigorotalk.backend.domain.coffeechat.dto.CoffeeChatApplyRequestDto;
+import app.sigorotalk.backend.domain.coffeechat.dto.CoffeeChatApplyResponseDto;
+import app.sigorotalk.backend.domain.coffeechat.dto.MyChatListResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/chats")
+@RequiredArgsConstructor
 public class CoffeeChatController {
+    private final CoffeeChatService coffeeChatService;
 
-    // TODO: [POST /] 커피챗 신청 API (Body에 mentorId 포함)
-    // public ResponseEntity<?> applyForChat( ... )
+    @PostMapping
+    public ResponseEntity<ApiResponse<CoffeeChatApplyResponseDto>> applyForChat(
+            @Valid @RequestBody CoffeeChatApplyRequestDto requestDto,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        Long menteeId = Long.valueOf(userDetails.getUsername());
+        CoffeeChatApplyResponseDto responseDto = coffeeChatService.applyForChat(requestDto, menteeId);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(responseDto));
+    }
 
-    // TODO: [GET /me] 나의 커피챗 목록 조회 API (멘토/멘티 공용)
-    // public ResponseEntity<?> getMyChats( ... )
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<List<MyChatListResponseDto>>> getMyChats(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        Long userId = Long.valueOf(userDetails.getUsername());
+        List<MyChatListResponseDto> responseDto = coffeeChatService.getMyChats(userId);
+        return ResponseEntity.ok(ApiResponse.success(responseDto));
+    }
 
-    // TODO: [PATCH /{chatId}/accept] (멘토) 커피챗 수락 API
-    // public ResponseEntity<?> acceptChat( ... )
+    @PatchMapping("/{chatId}/accept")
+    public ResponseEntity<ApiResponse<ChatStatusUpdateResponseDto>> acceptChat(
+            @PathVariable("chatId") Long applicationId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        Long mentorId = Long.valueOf(userDetails.getUsername());
+        // 수정된 서비스 메서드 호출
+        ChatStatusUpdateResponseDto responseDto = coffeeChatService.acceptChat(applicationId, mentorId);
+        return ResponseEntity.ok(ApiResponse.success(responseDto));
+    }
 
-    // TODO: [PATCH /{chatId}/reject] (멘토) 커피챗 거절 API
-    // public ResponseEntity<?> rejectChat( ... )
+    @PatchMapping("/{chatId}/reject")
+    public ResponseEntity<ApiResponse<ChatStatusUpdateResponseDto>> rejectChat(
+            @PathVariable("chatId") Long applicationId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        Long mentorId = Long.valueOf(userDetails.getUsername());
+        // 수정된 서비스 메서드 호출
+        ChatStatusUpdateResponseDto responseDto = coffeeChatService.rejectChat(applicationId, mentorId);
+        return ResponseEntity.ok(ApiResponse.success(responseDto));
+    }
 
-    // TODO: [PATCH /{chatId}/complete] (멘티) 커피챗 완료 API
-    // public ResponseEntity<?> completeChat( ... )
-
+    @PatchMapping("/{chatId}/complete")
+    public ResponseEntity<ApiResponse<ChatStatusUpdateResponseDto>> completeChat(
+            @PathVariable("chatId") Long applicationId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        Long menteeId = Long.valueOf(userDetails.getUsername());
+        // 수정된 서비스 메서드 호출
+        ChatStatusUpdateResponseDto responseDto = coffeeChatService.completeChat(applicationId, menteeId);
+        return ResponseEntity.ok(ApiResponse.success(responseDto));
+    }
 }

--- a/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatController.java
+++ b/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatController.java
@@ -12,7 +12,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 

--- a/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatErrorCode.java
+++ b/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatErrorCode.java
@@ -10,7 +10,6 @@ import org.springframework.http.HttpStatus;
 public enum CoffeeChatErrorCode implements ErrorCode {
 
     MENTOR_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 멘토 정보를 찾을 수 없습니다."),
-    MENTEE_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 멘티 정보를 찾을 수 없습니다."),
     COFFEE_CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 커피챗 신청 정보를 찾을 수 없습니다."),
     NO_AUTHORITY_TO_UPDATE_STATUS(HttpStatus.FORBIDDEN, 403, "해당 커피챗의 상태를 변경할 권한이 없습니다."),
     INVALID_STATUS_FOR_COMPLETION(HttpStatus.BAD_REQUEST, 400, "수락(ACCEPTED) 상태의 커피챗만 완료 처리할 수 있습니다."),

--- a/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatErrorCode.java
+++ b/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatErrorCode.java
@@ -1,0 +1,23 @@
+package app.sigorotalk.backend.domain.coffeechat;
+
+import app.sigorotalk.backend.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CoffeeChatErrorCode implements ErrorCode {
+
+    MENTOR_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 멘토 정보를 찾을 수 없습니다."),
+    MENTEE_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 멘티 정보를 찾을 수 없습니다."),
+    COFFEE_CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 커피챗 신청 정보를 찾을 수 없습니다."),
+    NO_AUTHORITY_TO_UPDATE_STATUS(HttpStatus.FORBIDDEN, 403, "해당 커피챗의 상태를 변경할 권한이 없습니다."),
+    INVALID_STATUS_FOR_COMPLETION(HttpStatus.BAD_REQUEST, 400, "수락(ACCEPTED) 상태의 커피챗만 완료 처리할 수 있습니다."),
+    CANNOT_CHANGE_STATUS(HttpStatus.BAD_REQUEST, 400, "현재 상태에서는 요청한 작업으로 상태를 변경할 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+}

--- a/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatService.java
+++ b/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatService.java
@@ -1,15 +1,96 @@
 package app.sigorotalk.backend.domain.coffeechat;
 
+import app.sigorotalk.backend.common.exception.BusinessException;
+import app.sigorotalk.backend.domain.coffeechat.dto.ChatStatusUpdateResponseDto;
+import app.sigorotalk.backend.domain.coffeechat.dto.CoffeeChatApplyRequestDto;
+import app.sigorotalk.backend.domain.coffeechat.dto.CoffeeChatApplyResponseDto;
+import app.sigorotalk.backend.domain.coffeechat.dto.MyChatListResponseDto;
+import app.sigorotalk.backend.domain.mentor.Mentor;
+import app.sigorotalk.backend.domain.mentor.MentorRepository;
+import app.sigorotalk.backend.domain.user.User;
+import app.sigorotalk.backend.domain.user.UserErrorCode;
+import app.sigorotalk.backend.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class CoffeeChatService {
-    // TODO: 커피챗 신청 로직 구현
+    private final CoffeeChatApplicationRepository coffeeChatApplicationRepository;
+    private final UserRepository userRepository;
+    private final MentorRepository mentorRepository;
 
-    // TODO: (멘토) 커피챗 수락/거절 로직 구현
+    @Transactional
+    public CoffeeChatApplyResponseDto applyForChat(CoffeeChatApplyRequestDto requestDto, Long menteeId) {
+        User mentee = userRepository.findById(menteeId)
+                .orElseThrow(() -> new BusinessException(CoffeeChatErrorCode.MENTEE_NOT_FOUND));
+        Mentor mentor = mentorRepository.findById(requestDto.getMentorId())
+                .orElseThrow(() -> new BusinessException(CoffeeChatErrorCode.MENTOR_NOT_FOUND));
 
-    // TODO: (멘티) 커피챗 완료 처리 로직 구현
+        CoffeeChatApplication application = CoffeeChatApplication.builder()
+                .mentee(mentee)
+                .mentor(mentor)
+                .status(CoffeeChatApplication.Status.PENDING)
+                .applicationDate(LocalDateTime.now())
+                .build();
 
-    // TODO: 나의 커피챗 목록 조회 로직 구현 (멘토/멘티 공용)
+        CoffeeChatApplication savedApplication = coffeeChatApplicationRepository.save(application);
+        return CoffeeChatApplyResponseDto.from(savedApplication);
+    }
 
+    @Transactional(readOnly = true)
+    public List<MyChatListResponseDto> getMyChats(Long userId) {
+        List<CoffeeChatApplication> myApplications = coffeeChatApplicationRepository.findMyChatsByUserId(userId);
+        return myApplications.stream()
+                .map(MyChatListResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public ChatStatusUpdateResponseDto acceptChat(Long applicationId, Long mentorUserId) {
+        CoffeeChatApplication application = findApplicationById(applicationId);
+        User mentorUser = findUserById(mentorUserId);
+
+        application.accept(mentorUser);
+
+        return ChatStatusUpdateResponseDto.from(application);
+    }
+
+    @Transactional
+    public ChatStatusUpdateResponseDto rejectChat(Long applicationId, Long mentorUserId) {
+        CoffeeChatApplication application = findApplicationById(applicationId);
+        User mentorUser = findUserById(mentorUserId);
+
+        application.reject(mentorUser);
+
+        return ChatStatusUpdateResponseDto.from(application);
+    }
+
+    @Transactional
+    public ChatStatusUpdateResponseDto completeChat(Long applicationId, Long menteeUserId) {
+        CoffeeChatApplication application = findApplicationById(applicationId);
+        User menteeUser = findUserById(menteeUserId);
+
+        application.complete(menteeUser);
+
+        return ChatStatusUpdateResponseDto.from(application);
+    }
+
+    // --- private 헬퍼 메서드: 중복되는 조회 로직 분리 ---
+    private CoffeeChatApplication findApplicationById(Long applicationId) {
+        return coffeeChatApplicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(CoffeeChatErrorCode.COFFEE_CHAT_NOT_FOUND));
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    }
 }
+
+

--- a/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatService.java
+++ b/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatService.java
@@ -27,8 +27,7 @@ public class CoffeeChatService {
 
     @Transactional
     public CoffeeChatApplyResponseDto applyForChat(CoffeeChatApplyRequestDto requestDto, Long menteeId) {
-        User mentee = userRepository.findById(menteeId)
-                .orElseThrow(() -> new BusinessException(CoffeeChatErrorCode.MENTEE_NOT_FOUND));
+        User mentee = findUserById(menteeId);
         Mentor mentor = mentorRepository.findById(requestDto.getMentorId())
                 .orElseThrow(() -> new BusinessException(CoffeeChatErrorCode.MENTOR_NOT_FOUND));
 

--- a/src/main/java/app/sigorotalk/backend/domain/coffeechat/dto/ChatStatusUpdateResponseDto.java
+++ b/src/main/java/app/sigorotalk/backend/domain/coffeechat/dto/ChatStatusUpdateResponseDto.java
@@ -2,7 +2,7 @@ package app.sigorotalk.backend.domain.coffeechat.dto;
 
 import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplication;
 
-public record ChatStatusUpdateResponseDto(Long applicationId, String updatedStatus) {
+public record ChatStatusUpdateResponseDto(Long applicationId, String status) {
     public static ChatStatusUpdateResponseDto from(CoffeeChatApplication application) {
         return new ChatStatusUpdateResponseDto(application.getId(), application.getStatus().name());
     }

--- a/src/main/java/app/sigorotalk/backend/domain/coffeechat/dto/ChatStatusUpdateResponseDto.java
+++ b/src/main/java/app/sigorotalk/backend/domain/coffeechat/dto/ChatStatusUpdateResponseDto.java
@@ -1,0 +1,9 @@
+package app.sigorotalk.backend.domain.coffeechat.dto;
+
+import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplication;
+
+public record ChatStatusUpdateResponseDto(Long applicationId, String updatedStatus) {
+    public static ChatStatusUpdateResponseDto from(CoffeeChatApplication application) {
+        return new ChatStatusUpdateResponseDto(application.getId(), application.getStatus().name());
+    }
+}

--- a/src/main/java/app/sigorotalk/backend/domain/coffeechat/dto/CoffeeChatApplyRequestDto.java
+++ b/src/main/java/app/sigorotalk/backend/domain/coffeechat/dto/CoffeeChatApplyRequestDto.java
@@ -1,0 +1,13 @@
+package app.sigorotalk.backend.domain.coffeechat.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CoffeeChatApplyRequestDto {
+
+    @NotNull(message = "멘토 ID는 필수입니다.")
+    private Long mentorId;
+}

--- a/src/main/java/app/sigorotalk/backend/domain/coffeechat/dto/CoffeeChatApplyResponseDto.java
+++ b/src/main/java/app/sigorotalk/backend/domain/coffeechat/dto/CoffeeChatApplyResponseDto.java
@@ -1,0 +1,13 @@
+package app.sigorotalk.backend.domain.coffeechat.dto;
+
+import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplication;
+
+public record CoffeeChatApplyResponseDto(Long applicationId, String mentorName, String status) {
+    public static CoffeeChatApplyResponseDto from(CoffeeChatApplication application) {
+        return new CoffeeChatApplyResponseDto(
+                application.getId(),
+                application.getMentor().getUser().getName(),
+                application.getStatus().name()
+        );
+    }
+}

--- a/src/main/java/app/sigorotalk/backend/domain/coffeechat/dto/MyChatListResponseDto.java
+++ b/src/main/java/app/sigorotalk/backend/domain/coffeechat/dto/MyChatListResponseDto.java
@@ -1,0 +1,47 @@
+package app.sigorotalk.backend.domain.coffeechat.dto;
+
+import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplication;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MyChatListResponseDto(
+        Long applicationId,
+        UserInfo mentor,
+        UserInfo mentee,
+        String status,
+        LocalDateTime applicationDate,
+        String contactInfo
+) {
+    public static MyChatListResponseDto from(CoffeeChatApplication application) {
+        UserInfo mentorInfo = new UserInfo(
+                application.getMentor().getUser().getName(),
+                application.getMentor().getProfileImageUrl()
+        );
+
+        UserInfo menteeInfo = new UserInfo(
+                application.getMentee().getName(),
+                null // 멘티는 프로필 이미지가 없음
+        );
+
+        String contact = null;
+        if (List.of(CoffeeChatApplication.Status.ACCEPTED, CoffeeChatApplication.Status.COMPLETED)
+                .contains(application.getStatus())) {
+            contact = application.getMentor().getUser().getEmail();
+        }
+
+
+        return new MyChatListResponseDto(
+                application.getId(),
+                mentorInfo,
+                menteeInfo,
+                application.getStatus().name(),
+                application.getApplicationDate(),
+                contact
+        );
+    }
+
+    // record 내부에 다른 record를 정의할 수 있습니다.
+    public record UserInfo(String name, String profileImageUrl) {
+    }
+}

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/MentorService.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/MentorService.java
@@ -33,7 +33,7 @@ public class MentorService {
                 .orElseThrow(() -> new BusinessException(CommonErrorCode.NOT_FOUND));
 
         // 멘토의 리뷰 목록 조회
-        List<Review> reviews = reviewRepository.findByCoffeeChatApplication_Mentor_Id(mentorId);
+        List<Review> reviews = reviewRepository.findByCoffeeChatApplicationMentorId(mentorId);
 
         return MentorDetailResponseDto.from(mentor, reviews);
     }

--- a/src/main/java/app/sigorotalk/backend/domain/review/ReviewRepository.java
+++ b/src/main/java/app/sigorotalk/backend/domain/review/ReviewRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     // 특정 커피챗 신청(application_id)에 연결된 리뷰 찾기
-    List<Review> findByCoffeeChatApplication_Mentor_Id(Long mentorId);
+    List<Review> findByCoffeeChatApplicationMentorId(Long mentorId);
 }

--- a/src/main/java/app/sigorotalk/backend/domain/user/UserErrorCode.java
+++ b/src/main/java/app/sigorotalk/backend/domain/user/UserErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 사용자를 찾을 수 없습니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, 409, "이미 존재하는 이메일입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/test/java/app/sigorotalk/backend/config/coffeechat/CoffeeChatApplicationRepositoryTest.java
+++ b/src/test/java/app/sigorotalk/backend/config/coffeechat/CoffeeChatApplicationRepositoryTest.java
@@ -1,0 +1,69 @@
+package app.sigorotalk.backend.config.coffeechat;
+
+import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplication;
+import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplicationRepository;
+import app.sigorotalk.backend.domain.mentor.Mentor;
+import app.sigorotalk.backend.domain.mentor.MentorRepository;
+import app.sigorotalk.backend.domain.user.User;
+import app.sigorotalk.backend.domain.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class CoffeeChatApplicationRepositoryTest {
+
+    @Autowired
+    private CoffeeChatApplicationRepository coffeeChatApplicationRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private MentorRepository mentorRepository;
+
+    private User user1, user2, user3;
+    private Mentor mentor2, mentor3;
+
+    @BeforeEach
+    void setUp() {
+        user1 = userRepository.save(User.builder().email("user1@test.com").name("유저1").password("pw").role(User.Role.ROLE_USER).build());
+        user2 = userRepository.save(User.builder().email("user2@test.com").name("유저2_멘토").password("pw").role(User.Role.ROLE_MENTOR).build());
+        user3 = userRepository.save(User.builder().email("user3@test.com").name("유저3_멘토").password("pw").role(User.Role.ROLE_MENTOR).build());
+
+        mentor2 = mentorRepository.save(Mentor.builder().user(user2).build());
+        mentor3 = mentorRepository.save(Mentor.builder().user(user3).build());
+    }
+
+    @Test
+    @DisplayName("findMyChatsByUserId: 특정 유저가 멘토이거나 멘티인 모든 커피챗을 조회한다.")
+    void findMyChatsByUserId_whenUserIsBothMentorAndMentee() {
+        // given
+        // 시나리오 1: user2가 멘토, user1이 멘티
+        CoffeeChatApplication app1 = coffeeChatApplicationRepository.save(CoffeeChatApplication.builder()
+                .mentor(mentor2).mentee(user1).status(CoffeeChatApplication.Status.PENDING).applicationDate(LocalDateTime.now().minusDays(2)).build());
+        // 시나리오 2: user3이 멘토, user2가 멘티
+        CoffeeChatApplication app2 = coffeeChatApplicationRepository.save(CoffeeChatApplication.builder()
+                .mentor(mentor3).mentee(user2).status(CoffeeChatApplication.Status.ACCEPTED).applicationDate(LocalDateTime.now().minusDays(1)).build());
+        // 시나리오 3: user2와 무관한 채팅
+        coffeeChatApplicationRepository.save(CoffeeChatApplication.builder()
+                .mentor(mentor3).mentee(user1).status(CoffeeChatApplication.Status.COMPLETED).applicationDate(LocalDateTime.now()).build());
+
+        // when (user2로 조회)
+        List<CoffeeChatApplication> result = coffeeChatApplicationRepository.findMyChatsByUserId(user2.getId());
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(CoffeeChatApplication::getId)
+                .containsExactlyInAnyOrder(app1.getId(), app2.getId());
+
+        // JOIN FETCH 검증
+        assertThat(result.get(0).getMentor().getUser()).isNotNull();
+        assertThat(result.get(0).getMentee()).isNotNull();
+    }
+}

--- a/src/test/java/app/sigorotalk/backend/config/coffeechat/CoffeeChatApplicationRepositoryTest.java
+++ b/src/test/java/app/sigorotalk/backend/config/coffeechat/CoffeeChatApplicationRepositoryTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,43 +28,47 @@ class CoffeeChatApplicationRepositoryTest {
     @Autowired
     private MentorRepository mentorRepository;
 
-    private User user1, user2, user3;
+    private User user1_mentee, user2_both, user3_mentor;
     private Mentor mentor2, mentor3;
 
     @BeforeEach
     void setUp() {
-        user1 = userRepository.save(User.builder().email("user1@test.com").name("유저1").password("pw").role(User.Role.ROLE_USER).build());
-        user2 = userRepository.save(User.builder().email("user2@test.com").name("유저2_멘토").password("pw").role(User.Role.ROLE_MENTOR).build());
-        user3 = userRepository.save(User.builder().email("user3@test.com").name("유저3_멘토").password("pw").role(User.Role.ROLE_MENTOR).build());
+        user1_mentee = userRepository.save(User.builder().email("mentee1@test.com").name("멘티1").password("pw").role(User.Role.ROLE_USER).build());
+        user2_both = userRepository.save(User.builder().email("user2@test.com").name("유저2_멘토겸멘티").password("pw").role(User.Role.ROLE_MENTOR).build());
+        user3_mentor = userRepository.save(User.builder().email("mentor3@test.com").name("멘토3").password("pw").role(User.Role.ROLE_MENTOR).build());
 
-        mentor2 = mentorRepository.save(Mentor.builder().user(user2).build());
-        mentor3 = mentorRepository.save(Mentor.builder().user(user3).build());
+        mentor2 = mentorRepository.save(Mentor.builder().user(user2_both).build());
+        mentor3 = mentorRepository.save(Mentor.builder().user(user3_mentor).build());
     }
 
     @Test
-    @DisplayName("findMyChatsByUserId: 특정 유저가 멘토이거나 멘티인 모든 커피챗을 조회한다.")
+    @DisplayName("findMyChatsByUserId: 유저가 멘토/멘티인 모든 채팅을 조회하고, 최신순으로 정렬한다.")
     void findMyChatsByUserId_whenUserIsBothMentorAndMentee() {
         // given
-        // 시나리오 1: user2가 멘토, user1이 멘티
+        // 시나리오 1: user2가 멘토, user1이 멘티 (중간 날짜)
         CoffeeChatApplication app1 = coffeeChatApplicationRepository.save(CoffeeChatApplication.builder()
-                .mentor(mentor2).mentee(user1).status(CoffeeChatApplication.Status.PENDING).applicationDate(LocalDateTime.now().minusDays(2)).build());
-        // 시나리오 2: user3이 멘토, user2가 멘티
+                .mentor(mentor2).mentee(user1_mentee).status(CoffeeChatApplication.Status.PENDING).applicationDate(LocalDateTime.now().minusDays(1)).build());
+        // 시나리오 2: user3이 멘토, user2가 멘티 (가장 최신)
         CoffeeChatApplication app2 = coffeeChatApplicationRepository.save(CoffeeChatApplication.builder()
-                .mentor(mentor3).mentee(user2).status(CoffeeChatApplication.Status.ACCEPTED).applicationDate(LocalDateTime.now().minusDays(1)).build());
+                .mentor(mentor3).mentee(user2_both).status(CoffeeChatApplication.Status.ACCEPTED).applicationDate(LocalDateTime.now()).build());
         // 시나리오 3: user2와 무관한 채팅
         coffeeChatApplicationRepository.save(CoffeeChatApplication.builder()
-                .mentor(mentor3).mentee(user1).status(CoffeeChatApplication.Status.COMPLETED).applicationDate(LocalDateTime.now()).build());
+                .mentor(mentor3).mentee(user1_mentee).status(CoffeeChatApplication.Status.COMPLETED).applicationDate(LocalDateTime.now().minusDays(3)).build());
 
         // when (user2로 조회)
-        List<CoffeeChatApplication> result = coffeeChatApplicationRepository.findMyChatsByUserId(user2.getId());
+        List<CoffeeChatApplication> result = coffeeChatApplicationRepository.findMyChatsByUserId(user2_both.getId());
 
         // then
+        // 1. 개수 및 내용 검증 (순서와 상관없이 올바른 데이터가 포함되었는지)
         assertThat(result).hasSize(2);
         assertThat(result).extracting(CoffeeChatApplication::getId)
                 .containsExactlyInAnyOrder(app1.getId(), app2.getId());
 
-        // JOIN FETCH 검증
-        assertThat(result.get(0).getMentor().getUser()).isNotNull();
-        assertThat(result.get(0).getMentee()).isNotNull();
+        // 2. 정렬(ORDER BY) 검증 (최신순으로 정렬되었는지)
+        assertThat(result).isSortedAccordingTo(Comparator.comparing(CoffeeChatApplication::getApplicationDate).reversed());
+
+        // 3. JOIN FETCH 검증 (첫번째 결과는 가장 최신인 app2여야 함)
+        assertThat(result.get(0).getMentor().getUser().getName()).isEqualTo("멘토3");
+        assertThat(result.get(0).getMentee().getName()).isEqualTo("유저2_멘토겸멘티");
     }
 }

--- a/src/test/java/app/sigorotalk/backend/config/coffeechat/CoffeeChatApplicationTest.java
+++ b/src/test/java/app/sigorotalk/backend/config/coffeechat/CoffeeChatApplicationTest.java
@@ -1,0 +1,134 @@
+package app.sigorotalk.backend.config.coffeechat;
+
+import app.sigorotalk.backend.common.exception.BusinessException;
+import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplication;
+import app.sigorotalk.backend.domain.mentor.Mentor;
+import app.sigorotalk.backend.domain.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CoffeeChatApplicationTest {
+
+    private User mentorUser;
+    private User menteeUser;
+    private User anotherUser;
+    private Mentor mentor;
+
+    @BeforeEach
+    void setUp() {
+        mentorUser = User.builder().id(1L).name("테스트멘토").build();
+        menteeUser = User.builder().id(2L).name("테스트멘티").build();
+        anotherUser = User.builder().id(3L).name("다른사용자").build();
+        mentor = Mentor.builder().id(1L).user(mentorUser).build();
+    }
+
+    private CoffeeChatApplication createPendingApplication() {
+        return CoffeeChatApplication.builder()
+                .id(1L)
+                .mentor(mentor)
+                .mentee(menteeUser)
+                .status(CoffeeChatApplication.Status.PENDING)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("커피챗 수락(accept) 테스트")
+    class AcceptTest {
+        @Test
+        @DisplayName("성공: 멘토가 PENDING 상태의 신청을 수락한다.")
+        void accept_Success() {
+            CoffeeChatApplication application = createPendingApplication();
+            application.accept(mentorUser);
+            assertThat(application.getStatus()).isEqualTo(CoffeeChatApplication.Status.ACCEPTED);
+            assertThat(application.getAcceptedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("실패: 멘토가 아닌 다른 사용자가 수락을 시도하면 예외가 발생한다.")
+        void accept_Failure_NoAuthority() {
+            CoffeeChatApplication application = createPendingApplication();
+            assertThatThrownBy(() -> application.accept(anotherUser))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 커피챗의 상태를 변경할 권한이 없습니다.");
+        }
+
+        @Test
+        @DisplayName("실패: PENDING 상태가 아닌 신청을 수락하면 예외가 발생한다.")
+        void accept_Failure_InvalidStatus() {
+            CoffeeChatApplication application = createPendingApplication();
+            application.accept(mentorUser);
+            assertThatThrownBy(() -> application.accept(mentorUser))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("현재 상태에서는 요청한 작업으로 상태를 변경할 수 없습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("커피챗 거절(reject) 테스트")
+    class RejectTest {
+        @Test
+        @DisplayName("성공: 멘토가 PENDING 상태의 신청을 거절한다.")
+        void reject_Success() {
+            CoffeeChatApplication application = createPendingApplication();
+            application.reject(mentorUser);
+            assertThat(application.getStatus()).isEqualTo(CoffeeChatApplication.Status.REJECTED);
+            assertThat(application.getAcceptedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("실패: 멘토가 아닌 다른 사용자가 거절하면 예외가 발생한다.")
+        void reject_Failure_NoAuthority() {
+            CoffeeChatApplication application = createPendingApplication();
+            assertThatThrownBy(() -> application.reject(menteeUser))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 커피챗의 상태를 변경할 권한이 없습니다.");
+        }
+
+        @Test
+        @DisplayName("실패: PENDING 상태가 아닌 신청을 거절하면 예외가 발생한다.")
+        void reject_Failure_InvalidStatus() {
+            CoffeeChatApplication application = createPendingApplication();
+            application.accept(mentorUser);
+            assertThatThrownBy(() -> application.reject(mentorUser))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("현재 상태에서는 요청한 작업으로 상태를 변경할 수 없습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("커피챗 완료(complete) 테스트")
+    class CompleteTest {
+        @Test
+        @DisplayName("성공: 멘티가 ACCEPTED 상태의 커피챗을 완료 처리한다.")
+        void complete_Success() {
+            CoffeeChatApplication application = createPendingApplication();
+            application.accept(mentorUser);
+            application.complete(menteeUser);
+            assertThat(application.getStatus()).isEqualTo(CoffeeChatApplication.Status.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("실패: 멘티가 아닌 다른 사용자가 완료를 시도하면 예외가 발생한다.")
+        void complete_Failure_NoAuthority() {
+            CoffeeChatApplication application = createPendingApplication();
+            application.accept(mentorUser);
+            assertThatThrownBy(() -> application.complete(anotherUser))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 커피챗의 상태를 변경할 권한이 없습니다.");
+        }
+
+        @Test
+        @DisplayName("실패: ACCEPTED 상태가 아닌 커피챗을 완료하면 예외가 발생한다.")
+        void complete_Failure_InvalidStatus() {
+            CoffeeChatApplication application = createPendingApplication();
+            assertThatThrownBy(() -> application.complete(menteeUser))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("수락(ACCEPTED) 상태의 커피챗만 완료 처리할 수 있습니다.");
+        }
+    }
+}

--- a/src/test/java/app/sigorotalk/backend/config/coffeechat/CoffeeChatServiceTest.java
+++ b/src/test/java/app/sigorotalk/backend/config/coffeechat/CoffeeChatServiceTest.java
@@ -120,19 +120,33 @@ class CoffeeChatServiceTest {
     void getMyChats_Success() {
         // given
         long userId = 1L;
-        User user = User.builder().id(userId).name("테스트유저").build();
-        Mentor mentor = Mentor.builder().user(user).build();
-        CoffeeChatApplication app1 = CoffeeChatApplication.builder().mentor(mentor).mentee(user).status(CoffeeChatApplication.Status.PENDING).build();
-        CoffeeChatApplication app2 = CoffeeChatApplication.builder().mentor(mentor).mentee(user).status(CoffeeChatApplication.Status.ACCEPTED).build();
+        User menteeUser = User.builder().id(userId).name("테스트멘티").build();
+        User mentorUser = User.builder().id(2L).name("테스트멘토").build();
+        Mentor mentor = Mentor.builder().user(mentorUser).profileImageUrl("mentor.jpg").build();
 
-        when(coffeeChatApplicationRepository.findMyChatsByUserId(userId)).thenReturn(List.of(app1, app2));
+        CoffeeChatApplication app1 = CoffeeChatApplication.builder()
+                .id(100L)
+                .mentor(mentor)
+                .mentee(menteeUser)
+                .status(CoffeeChatApplication.Status.ACCEPTED)
+                .build();
+
+        when(coffeeChatApplicationRepository.findMyChatsByUserId(userId)).thenReturn(List.of(app1));
 
         // when
         List<MyChatListResponseDto> result = coffeeChatService.getMyChats(userId);
 
         // then
-        assertThat(result).hasSize(2);
         verify(coffeeChatApplicationRepository, times(1)).findMyChatsByUserId(userId);
+
+        // DTO의 내용까지 상세하게 검증
+        assertThat(result).hasSize(1);
+        MyChatListResponseDto resultDto = result.get(0);
+        assertThat(resultDto.applicationId()).isEqualTo(100L);
+        assertThat(resultDto.mentor().name()).isEqualTo("테스트멘토");
+        assertThat(resultDto.mentee().name()).isEqualTo("테스트멘티");
+        assertThat(resultDto.status()).isEqualTo("ACCEPTED");
+        assertThat(resultDto.mentor().profileImageUrl()).isEqualTo("mentor.jpg");
     }
 
     @Test

--- a/src/test/java/app/sigorotalk/backend/config/coffeechat/CoffeeChatServiceTest.java
+++ b/src/test/java/app/sigorotalk/backend/config/coffeechat/CoffeeChatServiceTest.java
@@ -1,0 +1,133 @@
+package app.sigorotalk.backend.config.coffeechat;
+
+import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplication;
+import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplicationRepository;
+import app.sigorotalk.backend.domain.coffeechat.CoffeeChatService;
+import app.sigorotalk.backend.domain.coffeechat.dto.CoffeeChatApplyRequestDto;
+import app.sigorotalk.backend.domain.coffeechat.dto.CoffeeChatApplyResponseDto;
+import app.sigorotalk.backend.domain.coffeechat.dto.MyChatListResponseDto;
+import app.sigorotalk.backend.domain.mentor.Mentor;
+import app.sigorotalk.backend.domain.mentor.MentorRepository;
+import app.sigorotalk.backend.domain.user.User;
+import app.sigorotalk.backend.domain.user.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CoffeeChatServiceTest {
+
+    @InjectMocks
+    private CoffeeChatService coffeeChatService;
+    @Mock
+    private CoffeeChatApplicationRepository coffeeChatApplicationRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private MentorRepository mentorRepository;
+
+    @Test
+    @DisplayName("신청 성공: applyForChat은 PENDING 상태의 신청서를 생성하고 save를 호출한다.")
+    void applyForChat_Success() {
+        long menteeId = 1L;
+        long mentorId = 2L;
+        CoffeeChatApplyRequestDto requestDto = new CoffeeChatApplyRequestDto();
+        ReflectionTestUtils.setField(requestDto, "mentorId", mentorId);
+        User mentee = User.builder().id(menteeId).build();
+        User mentorUser = User.builder().id(mentorId).name("테스트멘토").build();
+        Mentor mentor = Mentor.builder().id(mentorId).user(mentorUser).build();
+
+        when(userRepository.findById(menteeId)).thenReturn(Optional.of(mentee));
+        when(mentorRepository.findById(mentorId)).thenReturn(Optional.of(mentor));
+        when(coffeeChatApplicationRepository.save(any(CoffeeChatApplication.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        CoffeeChatApplyResponseDto response = coffeeChatService.applyForChat(requestDto, menteeId);
+
+        verify(coffeeChatApplicationRepository, times(1)).save(any(CoffeeChatApplication.class));
+        assertThat(response.status()).isEqualTo(CoffeeChatApplication.Status.PENDING.name());
+        assertThat(response.mentorName()).isEqualTo("테스트멘토");
+    }
+
+    @Test
+    @DisplayName("수락 성공: acceptChat은 올바른 엔티티를 찾아 accept() 메서드를 호출한다.")
+    void acceptChat_Success() {
+        long applicationId = 1L;
+        long mentorUserId = 2L;
+        User mentorUser = User.builder().id(mentorUserId).build();
+        CoffeeChatApplication application = spy(CoffeeChatApplication.builder().status(CoffeeChatApplication.Status.PENDING).build());
+
+        when(coffeeChatApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+        when(userRepository.findById(mentorUserId)).thenReturn(Optional.of(mentorUser));
+        doNothing().when(application).accept(any(User.class));
+
+        coffeeChatService.acceptChat(applicationId, mentorUserId);
+
+        verify(application, times(1)).accept(mentorUser);
+    }
+
+    @Test
+    @DisplayName("거절 성공: rejectChat은 올바른 엔티티를 찾아 reject() 메서드를 호출한다.")
+    void rejectChat_Success() {
+        long applicationId = 1L;
+        long mentorUserId = 2L;
+        User mentorUser = User.builder().id(mentorUserId).build();
+        CoffeeChatApplication application = spy(CoffeeChatApplication.builder().status(CoffeeChatApplication.Status.PENDING).build());
+
+        when(coffeeChatApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+        when(userRepository.findById(mentorUserId)).thenReturn(Optional.of(mentorUser));
+        doNothing().when(application).reject(any(User.class));
+
+        coffeeChatService.rejectChat(applicationId, mentorUserId);
+
+        verify(application, times(1)).reject(mentorUser);
+    }
+
+    @Test
+    @DisplayName("완료 성공: completeChat은 올바른 엔티티를 찾아 complete() 메서드를 호출한다.")
+    void completeChat_Success() {
+        long applicationId = 1L;
+        long menteeUserId = 3L;
+        User menteeUser = User.builder().id(menteeUserId).build();
+        CoffeeChatApplication application = spy(CoffeeChatApplication.builder().status(CoffeeChatApplication.Status.ACCEPTED).build());
+
+        when(coffeeChatApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+        when(userRepository.findById(menteeUserId)).thenReturn(Optional.of(menteeUser));
+        doNothing().when(application).complete(any(User.class));
+
+        coffeeChatService.completeChat(applicationId, menteeUserId);
+
+        verify(application, times(1)).complete(menteeUser);
+    }
+
+    @Test
+    @DisplayName("목록 조회 성공: getMyChats는 repository의 조회 결과를 DTO 리스트로 변환한다.")
+    void getMyChats_Success() {
+        // given
+        long userId = 1L;
+        User user = User.builder().id(userId).name("테스트유저").build();
+        Mentor mentor = Mentor.builder().user(user).build();
+        CoffeeChatApplication app1 = CoffeeChatApplication.builder().mentor(mentor).mentee(user).status(CoffeeChatApplication.Status.PENDING).build();
+        CoffeeChatApplication app2 = CoffeeChatApplication.builder().mentor(mentor).mentee(user).status(CoffeeChatApplication.Status.ACCEPTED).build();
+
+        when(coffeeChatApplicationRepository.findMyChatsByUserId(userId)).thenReturn(List.of(app1, app2));
+
+        // when
+        List<MyChatListResponseDto> result = coffeeChatService.getMyChats(userId);
+
+        // then
+        assertThat(result).hasSize(2);
+        verify(coffeeChatApplicationRepository, times(1)).findMyChatsByUserId(userId);
+    }
+}

--- a/src/test/java/app/sigorotalk/backend/config/mentor/MentorControllerTest.java
+++ b/src/test/java/app/sigorotalk/backend/config/mentor/MentorControllerTest.java
@@ -59,7 +59,7 @@ class MentorControllerTest {
     @Test
     @DisplayName("멘토 목록 조회 API 성공: 200 OK와 함께 페이징된 데이터를 반환한다.")
     @WithMockUser
-        // 인증된 사용자로 간주
+    // 인증된 사용자로 간주
     void getMentorListApi_Success() throws Exception {
         // when & then
         mockMvc.perform(get("/api/v1/mentors")

--- a/src/test/java/app/sigorotalk/backend/config/mentor/MentorControllerTest.java
+++ b/src/test/java/app/sigorotalk/backend/config/mentor/MentorControllerTest.java
@@ -59,7 +59,7 @@ class MentorControllerTest {
     @Test
     @DisplayName("멘토 목록 조회 API 성공: 200 OK와 함께 페이징된 데이터를 반환한다.")
     @WithMockUser
-    // 인증된 사용자로 간주
+        // 인증된 사용자로 간주
     void getMentorListApi_Success() throws Exception {
         // when & then
         mockMvc.perform(get("/api/v1/mentors")

--- a/src/test/java/app/sigorotalk/backend/config/mentor/MentorServiceTest.java
+++ b/src/test/java/app/sigorotalk/backend/config/mentor/MentorServiceTest.java
@@ -67,7 +67,7 @@ class MentorServiceTest {
         List<Review> reviews = Collections.emptyList();
 
         when(mentorRepository.findByIdWithUser(1L)).thenReturn(Optional.of(testMentor));
-        when(reviewRepository.findByCoffeeChatApplication_Mentor_Id(1L)).thenReturn(reviews);
+        when(reviewRepository.findByCoffeeChatApplicationMentorId(1L)).thenReturn(reviews);
 
         // when
         var result = mentorService.getMentorDetail(1L);


### PR DESCRIPTION
### Description

본 PR은 커피챗 기능의 핵심 로직(신청, 상태 관리, 조회)을 구현하고, 구현된 기능의 안정성을 보장하기 위한 단위 및 통합 테스트를 추가합니다.

주요 설계 변경 사항으로, 기존 서비스 레이어에 집중될 수 있는 비즈니스 로직을 `CoffeeChatApplication` 엔티티로 이전하여 도메인 객체가 스스로의 상태와 규칙을 관리하도록 했습니다. 이를 통해 도메인 모델의 응집도를 높이고 서비스 레이어의 복잡도를 낮추어 유지보수성을 향상시키고자 했습니다.

---

### 주요 변경 사항

#### 1. 기능 구현 (`feat`)

- **`CoffeeChatApplication` (도메인)**
    
    - 상태 변경(수락, 거절, 완료)과 관련된 비즈니스 로직 및 유효성 검증 책임을 서비스에서 엔티티로 위임했습니다.
        
    - `accept()`, `reject()`, `complete()` 메서드를 구현하여 상태 변경 로직을 캡슐화했습니다.
        
- **`CoffeeChatService` (서비스)**
    
    - 도메인 엔티티의 비즈니스 로직을 호출하고 트랜잭션을 관리하는 '조정자(Orchestrator)' 역할로 재정의했습니다.
        
    - `applyForChat`, `acceptChat` 등 기능에 필요한 공개 메서드를 구현했습니다.
        
- **`CoffeeChatApplicationRepository` (리포지토리)**
    
    - `findMyChatsByUserId` JPQL 쿼리에 `JOIN FETCH`를 적용하여 N+1 문제를 해결했습니다.
        
- **기타**
    
    - 커피챗 기능에 필요한 RESTful API 엔드포인트(`CoffeeChatController`), DTO(`record` 타입 활용), 전용 에러 코드(`CoffeeChatErrorCode`)를 추가했습니다.
        

---

#### 2. 테스트 구현 (`test`)

- **`CoffeeChatApplicationTest` (단위 테스트)**
    
    - `@Nested`를 사용하여 테스트를 그룹화하고, 엔티티의 모든 비즈니스 메서드에 대한 성공 및 예외 케이스를 검증합니다.
        
- **`CoffeeChatServiceTest` (단위 테스트)**
    
    - `Mockito`를 사용하여 외부 의존성을 격리하고, 서비스가 도메인 객체 및 리포지토리를 올바르게 호출하는지 `verify`를 통해 확인합니다.
        
- **`CoffeeChatApplicationRepositoryTest` (통합 테스트)**
    
    - `@DataJpaTest`를 사용하여 JPQL 쿼리가 실제 DB 환경에서 모든 조건(OR, JOIN FETCH)을 만족하며 정확하게 동작하는지 검증합니다.
        

---

#### 3. 리팩토링 (`refactor`)

- **`ReviewRepository`**
    
    - Spring Data JPA 네이밍 컨벤션에 따라 `findByCoffeeChatApplication_Mentor_Id`를 `findByCoffeeChatApplicationMentorId`로 수정하여 가독성을 개선했습니다.
        

---

### 리뷰 중점 사항

- `CoffeeChatApplication` 엔티티에 비즈니스 로직을 위임한 설계의 적절성 검토 부탁드립니다.
    
- 서비스 레이어의 역할이 명확하게 분리되었는지 확인 부탁드립니다.
    
- 테스트 코드에서 누락된 예외 케이스나 엣지 케이스가 있는지 검토해주시면 감사하겠습니다.