### PR TITLE
feat: 멘토 필터링 및 리뷰 작성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    testImplementation 'org.awaitility:awaitility:4.2.0' // 비동기 테스트를 위한 라이브러리
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,27 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
-tasks.named('test') {
+test {
     useJUnitPlatform()
+}
+
+def generated = layout.buildDirectory.dir("generated/querydsl")
+
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(generated)
+}
+
+clean.doLast {
+    delete(generated)
 }

--- a/src/main/java/app/sigorotalk/backend/BackendApplication.java
+++ b/src/main/java/app/sigorotalk/backend/BackendApplication.java
@@ -5,10 +5,12 @@ import org.springframework.boot.Banner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @Slf4j
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableAsync
 public class BackendApplication {
 
     public static void main(String[] args) {
@@ -17,7 +19,7 @@ public class BackendApplication {
         app.setBannerMode(Banner.Mode.OFF); // 실행 시, 처음에 뜨는 배너 출력 끄기
         app.run(args);
 
-		log.info("🚀BackendApplication started successfully.🚀");
-	}
+        log.info("🚀BackendApplication started successfully.🚀");
+    }
 
 }

--- a/src/main/java/app/sigorotalk/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/app/sigorotalk/backend/common/exception/GlobalExceptionHandler.java
@@ -78,6 +78,7 @@ public class GlobalExceptionHandler {
 
     /**
      * 요청 파라미터 검증 실패 처리
+     *
      * @Valid 어노테이션 검증 실패 시 발생
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/app/sigorotalk/backend/config/MetricsConfig.java
+++ b/src/main/java/app/sigorotalk/backend/config/MetricsConfig.java
@@ -2,16 +2,16 @@ package app.sigorotalk.backend.config;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/app/sigorotalk/backend/config/QueryDslConfig.java
+++ b/src/main/java/app/sigorotalk/backend/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package app.sigorotalk.backend.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/app/sigorotalk/backend/config/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/app/sigorotalk/backend/config/handler/CustomAuthenticationEntryPoint.java
@@ -2,13 +2,13 @@ package app.sigorotalk.backend.config.handler;
 
 import app.sigorotalk.backend.common.response.ApiResponse;
 import app.sigorotalk.backend.common.response.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 

--- a/src/main/java/app/sigorotalk/backend/domain/TestController.java
+++ b/src/main/java/app/sigorotalk/backend/domain/TestController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TestController {
 
     @GetMapping("/")
-    public String test(){
+    public String test() {
         return "SigorTalk";
     }
 }

--- a/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatController.java
+++ b/src/main/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatController.java
@@ -12,13 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/Mentor.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/Mentor.java
@@ -45,4 +45,9 @@ public class Mentor extends BaseTimeEntity {
     private BigDecimal averageRating;
 
     private Integer reviewCount;
+
+    public void updateRating(BigDecimal averageRating, Integer reviewCount) {
+        this.averageRating = averageRating;
+        this.reviewCount = reviewCount;
+    }
 }

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/MentorController.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/MentorController.java
@@ -7,10 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/mentors")
@@ -20,8 +17,12 @@ public class MentorController {
     private final MentorService mentorService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<Page<MentorListResponseDto>>> getMentorList(Pageable pageable) {
-        Page<MentorListResponseDto> mentorList = mentorService.getMentorList(pageable);
+    public ResponseEntity<ApiResponse<Page<MentorListResponseDto>>> getMentorList(
+            @RequestParam(required = false) String region,
+            @RequestParam(required = false) String expertise,
+            Pageable pageable
+    ) {
+        Page<MentorListResponseDto> mentorList = mentorService.getMentorList(region, expertise, pageable); // 수정
         return ResponseEntity.ok(ApiResponse.success(mentorList));
     }
 

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/MentorRepository.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/MentorRepository.java
@@ -1,19 +1,17 @@
 package app.sigorotalk.backend.domain.mentor;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface MentorRepository extends JpaRepository<Mentor, Long> {
+public interface MentorRepository extends JpaRepository<Mentor, Long>, MentorRepositoryCustom {
 
-    // 멘토 목록 조회 시 N+1 문제 해결을 위해 User를 fetch join
-    @Query(value = "SELECT m FROM Mentor m JOIN FETCH m.user ORDER BY m.id",
-            countQuery = "SELECT COUNT(m) FROM Mentor m")
-    Page<Mentor> findAllWithUser(Pageable pageable);
+//    // 멘토 목록 조회 시 N+1 문제 해결을 위해 User를 fetch join
+//    @Query(value = "SELECT m FROM Mentor m JOIN FETCH m.user ORDER BY m.id",
+//            countQuery = "SELECT COUNT(m) FROM Mentor m")
+//    Page<Mentor> findAllWithUser(Pageable pageable);
 
     // 멘토 상세 조회 시 User를 fetch join
     @Query("SELECT m FROM Mentor m JOIN FETCH m.user WHERE m.id = :mentorId")

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/MentorRepositoryCustom.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/MentorRepositoryCustom.java
@@ -1,0 +1,10 @@
+package app.sigorotalk.backend.domain.mentor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MentorRepositoryCustom {
+
+    Page<Mentor> findByFilters(String region, String expertise, Pageable pageable);
+
+}

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/MentorRepositoryImpl.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/MentorRepositoryImpl.java
@@ -1,0 +1,57 @@
+package app.sigorotalk.backend.domain.mentor;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static app.sigorotalk.backend.domain.mentor.QMentor.mentor;
+import static app.sigorotalk.backend.domain.user.QUser.user;
+
+
+@RequiredArgsConstructor
+public class MentorRepositoryImpl implements MentorRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Mentor> findByFilters(String region, String expertise, Pageable pageable) {
+        List<Mentor> content = queryFactory
+                .selectFrom(mentor)
+                .join(mentor.user, user).fetchJoin() // N+1 문제 해결을 위한 fetchJoin
+                .where(
+                        regionEq(region),
+                        expertiseEq(expertise)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(mentor.id.desc()) // 정렬 기준 추가
+                .fetch();
+
+        Long total = queryFactory
+                .select(mentor.count())
+                .from(mentor)
+                .where(
+                        regionEq(region),
+                        expertiseEq(expertise)
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    // region 파라미터가 있으면 해당 조건 반환, 없으면 null 반환
+    private BooleanExpression regionEq(String region) {
+        return StringUtils.hasText(region) ? mentor.region.eq(region) : null;
+    }
+
+    // expertise 파라미터가 있으면 해당 조건 반환, 없으면 null 반환
+    private BooleanExpression expertiseEq(String expertise) {
+        return StringUtils.hasText(expertise) ? mentor.expertise.contains(expertise) : null;
+    }
+}

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/MentorService.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/MentorService.java
@@ -5,13 +5,18 @@ import app.sigorotalk.backend.common.exception.CommonErrorCode;
 import app.sigorotalk.backend.domain.mentor.dto.MentorDetailResponseDto;
 import app.sigorotalk.backend.domain.mentor.dto.MentorListResponseDto;
 import app.sigorotalk.backend.domain.review.Review;
+import app.sigorotalk.backend.domain.review.ReviewCreatedEvent;
 import app.sigorotalk.backend.domain.review.ReviewRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 
 @Service
@@ -39,6 +44,31 @@ public class MentorService {
 
     // TODO: (관리자용) 멘토 등록 로직 구현
 
-    // TODO: (중요) 리뷰 작성 시 멘토 평점 및 리뷰 수 업데이트 로직 구현
+    /**
+     * ReviewCreatedEvent를 수신하여 멘토의 평점과 리뷰 수를 업데이트합니다.
+     *
+     * @Async 를 통해 이 로직은 별도의 스레드에서 비동기적으로 실행됩니다.
+     */
+    @Async
+    @EventListener
+    @Transactional
+    public void handleReviewCreatedEvent(ReviewCreatedEvent event) {
+        Long mentorId = event.getMentorId();
 
+        List<Review> reviews = reviewRepository.findByCoffeeChatApplicationMentorId(mentorId);
+        if (reviews.isEmpty()) {
+            return;
+        }
+
+        double average = reviews.stream()
+                .mapToInt(Review::getRating)
+                .average()
+                .orElse(0.0);
+        BigDecimal newAverageRating = BigDecimal.valueOf(average).setScale(1, RoundingMode.HALF_UP);
+
+        Mentor mentor = mentorRepository.findById(mentorId)
+                .orElseThrow(() -> new BusinessException(CommonErrorCode.NOT_FOUND));
+
+        mentor.updateRating(newAverageRating, reviews.size());
+    }
 }

--- a/src/main/java/app/sigorotalk/backend/domain/mentor/MentorService.java
+++ b/src/main/java/app/sigorotalk/backend/domain/mentor/MentorService.java
@@ -22,9 +22,8 @@ public class MentorService {
     private final MentorRepository mentorRepository;
     private final ReviewRepository reviewRepository;
 
-    public Page<MentorListResponseDto> getMentorList(Pageable pageable) {
-        // TODO: 필터링 기능 추가 (region, expertise 등)
-        return mentorRepository.findAllWithUser(pageable)
+    public Page<MentorListResponseDto> getMentorList(String region, String expertise, Pageable pageable) {
+        return mentorRepository.findByFilters(region, expertise, pageable)
                 .map(MentorListResponseDto::from);
     }
 

--- a/src/main/java/app/sigorotalk/backend/domain/review/Review.java
+++ b/src/main/java/app/sigorotalk/backend/domain/review/Review.java
@@ -3,14 +3,14 @@ package app.sigorotalk.backend.domain.review;
 import app.sigorotalk.backend.common.entity.BaseTimeEntity;
 import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplication;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "tb_review")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
 public class Review extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/app/sigorotalk/backend/domain/review/ReviewController.java
+++ b/src/main/java/app/sigorotalk/backend/domain/review/ReviewController.java
@@ -1,13 +1,37 @@
 package app.sigorotalk.backend.domain.review;
 
 
+import app.sigorotalk.backend.common.response.ApiResponse;
+import app.sigorotalk.backend.domain.review.dto.ReviewRequestDto;
+import app.sigorotalk.backend.domain.review.dto.ReviewResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/reviews")
+@RequiredArgsConstructor
 public class ReviewController {
 
-    // TODO: [POST /] 특정 커피챗에 대한 리뷰 작성 API
+    private final ReviewService reviewService;
 
+    @PostMapping
+    public ResponseEntity<ApiResponse<ReviewResponseDto>> createReview(
+            @Valid @RequestBody ReviewRequestDto requestDto,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        Long menteeId = Long.valueOf(userDetails.getUsername());
+        ReviewResponseDto responseDto = reviewService.createReview(requestDto, menteeId);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(responseDto));
+    }
 }

--- a/src/main/java/app/sigorotalk/backend/domain/review/ReviewCreatedEvent.java
+++ b/src/main/java/app/sigorotalk/backend/domain/review/ReviewCreatedEvent.java
@@ -1,0 +1,12 @@
+package app.sigorotalk.backend.domain.review;
+
+import lombok.Getter;
+
+@Getter
+public class ReviewCreatedEvent {
+    private final Long mentorId;
+
+    public ReviewCreatedEvent(Long mentorId) {
+        this.mentorId = mentorId;
+    }
+}

--- a/src/main/java/app/sigorotalk/backend/domain/review/ReviewErrorCode.java
+++ b/src/main/java/app/sigorotalk/backend/domain/review/ReviewErrorCode.java
@@ -1,0 +1,19 @@
+package app.sigorotalk.backend.domain.review;
+
+import app.sigorotalk.backend.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewErrorCode implements ErrorCode {
+    REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, 409, "리뷰는 한 번만 작성할 수 있습니다."),
+    COFFEE_CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "리뷰를 작성하려는 커피챗을 찾을 수 없습니다."),
+    INVALID_STATUS_FOR_REVIEW(HttpStatus.BAD_REQUEST, 400, "완료된 커피챗에만 리뷰를 작성할 수 있습니다."),
+    NO_AUTHORITY_TO_REVIEW(HttpStatus.FORBIDDEN, 403, "리뷰를 작성할 권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/app/sigorotalk/backend/domain/review/ReviewRepository.java
+++ b/src/main/java/app/sigorotalk/backend/domain/review/ReviewRepository.java
@@ -8,4 +8,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     // 특정 커피챗 신청(application_id)에 연결된 리뷰 찾기
     List<Review> findByCoffeeChatApplicationMentorId(Long mentorId);
+
+    boolean existsByCoffeeChatApplicationId(Long coffeeChatId);
 }

--- a/src/main/java/app/sigorotalk/backend/domain/review/ReviewService.java
+++ b/src/main/java/app/sigorotalk/backend/domain/review/ReviewService.java
@@ -1,11 +1,57 @@
 package app.sigorotalk.backend.domain.review;
 
+import app.sigorotalk.backend.common.exception.BusinessException;
+import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplication;
+import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplicationRepository;
+import app.sigorotalk.backend.domain.review.dto.ReviewRequestDto;
+import app.sigorotalk.backend.domain.review.dto.ReviewResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Service
+@RequiredArgsConstructor
 public class ReviewService {
 
-    // TODO: 리뷰 작성 로직 구현 (완료된 커피챗에 대해서만 가능하도록)
-    // TODO: 리뷰 작성 시 MentorService 호출하여 평점 업데이트 트리거
+    private final ReviewRepository reviewRepository;
+    private final CoffeeChatApplicationRepository coffeeChatApplicationRepository;
+    private final ApplicationEventPublisher eventPublisher; // 이벤트 발행기
 
+    @Transactional
+    public ReviewResponseDto createReview(ReviewRequestDto requestDto, Long menteeId) {
+        // 1. 중복 리뷰 작성 방지
+        if (reviewRepository.existsByCoffeeChatApplicationId(requestDto.getChatId())) {
+            throw new BusinessException(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
+        }
+
+        // 2. 커피챗 정보 조회
+        CoffeeChatApplication coffeeChat = coffeeChatApplicationRepository.findById(requestDto.getChatId())
+                .orElseThrow(() -> new BusinessException(ReviewErrorCode.COFFEE_CHAT_NOT_FOUND));
+
+        // 3. 상태 검증: COMPLETED 상태가 아니면 리뷰 작성 불가
+        if (coffeeChat.getStatus() != CoffeeChatApplication.Status.COMPLETED) {
+            throw new BusinessException(ReviewErrorCode.INVALID_STATUS_FOR_REVIEW);
+        }
+
+        // 4. 권한 검증: 요청자가 해당 커피챗의 멘티가 맞는지 확인
+        if (!Objects.equals(coffeeChat.getMentee().getId(), menteeId)) {
+            throw new BusinessException(ReviewErrorCode.NO_AUTHORITY_TO_REVIEW);
+        }
+
+        // Review 엔티티 생성 및 저장
+        Review newReview = Review.builder()
+                .coffeeChatApplication(coffeeChat)
+                .rating(requestDto.getRating())
+                .comment(requestDto.getComment())
+                .build();
+        reviewRepository.save(newReview);
+
+        // 5. 이벤트 발행!
+        eventPublisher.publishEvent(new ReviewCreatedEvent(coffeeChat.getMentor().getId()));
+
+        return ReviewResponseDto.from(newReview);
+    }
 }

--- a/src/main/java/app/sigorotalk/backend/domain/review/dto/ReviewRequestDto.java
+++ b/src/main/java/app/sigorotalk/backend/domain/review/dto/ReviewRequestDto.java
@@ -1,0 +1,24 @@
+package app.sigorotalk.backend.domain.review.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReviewRequestDto {
+
+    @NotNull(message = "커피챗 ID는 필수입니다.")
+    private Long chatId; // 어떤 커피챗에 대한 리뷰인지 식별
+
+    @NotNull(message = "평점은 필수입니다.")
+    @Min(value = 1, message = "평점은 1 이상이어야 합니다.")
+    @Max(value = 5, message = "평점은 5 이하여야 합니다.")
+    private Integer rating; // 1~5점
+
+    @NotBlank(message = "리뷰 내용은 필수입니다.")
+    private String comment; // 리뷰 코멘트
+}

--- a/src/main/java/app/sigorotalk/backend/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/app/sigorotalk/backend/domain/review/dto/ReviewResponseDto.java
@@ -1,0 +1,25 @@
+package app.sigorotalk.backend.domain.review.dto;
+
+import app.sigorotalk.backend.domain.review.Review;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReviewResponseDto {
+    private final Long reviewId;
+    private final Integer rating;
+    private final String comment;
+    private final LocalDateTime createdAt;
+
+    public static ReviewResponseDto from(Review review) {
+        return ReviewResponseDto.builder()
+                .reviewId(review.getId())
+                .rating(review.getRating())
+                .comment(review.getComment())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+}

--- a/src/test/java/app/sigorotalk/backend/config/coffeechat/CoffeeChatApplicationRepositoryTest.java
+++ b/src/test/java/app/sigorotalk/backend/config/coffeechat/CoffeeChatApplicationRepositoryTest.java
@@ -1,5 +1,6 @@
 package app.sigorotalk.backend.config.coffeechat;
 
+import app.sigorotalk.backend.config.QueryDslConfig;
 import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplication;
 import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplicationRepository;
 import app.sigorotalk.backend.domain.mentor.Mentor;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 import java.time.LocalDateTime;
 import java.util.Comparator;
@@ -19,6 +21,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@Import(QueryDslConfig.class)
 class CoffeeChatApplicationRepositoryTest {
 
     @Autowired

--- a/src/test/java/app/sigorotalk/backend/config/mentor/MentorControllerTest.java
+++ b/src/test/java/app/sigorotalk/backend/config/mentor/MentorControllerTest.java
@@ -88,6 +88,39 @@ class MentorControllerTest {
     }
 
     @Test
+    @DisplayName("멘토 목록 조회 API 성공: 필터링 조건과 함께 요청 시, 조건에 맞는 데이터만 반환한다.")
+    @WithMockUser
+    void getMentorListApi_WithFilter_Success() throws Exception {
+        // given
+        // 테스트 데이터 추가: 서울 지역, 다른 전문분야의 멘토
+        User anotherUser = User.builder()
+                .email("mentor2@example.com")
+                .password("password")
+                .name("다른멘토")
+                .role(User.Role.ROLE_MENTOR)
+                .build();
+        userRepository.save(anotherUser);
+
+        Mentor anotherMentor = Mentor.builder()
+                .user(anotherUser)
+                .region("서울") // 이 멘토는 '서울' 지역
+                .expertise("Python, Django") // 전문 분야는 다름
+                .build();
+        mentorRepository.save(anotherMentor);
+
+        // when & then: '서울' 지역으로만 필터링하여 API 호출
+        mockMvc.perform(get("/api/v1/mentors")
+                        .param("region", "서울") // '서울' 지역으로 필터링
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.response.content").isArray())
+                .andExpect(jsonPath("$.response.content.length()").value(1)) // 결과가 1개여야 함
+                .andExpect(jsonPath("$.response.content[0].name").value("다른멘토")) // '다른멘토'만 조회되어야 함
+                .andDo(print());
+    }
+
+    @Test
     @DisplayName("멘토 상세 조회 API 실패: 존재하지 않는 ID 요청 시 404 Not Found를 반환한다.")
     @WithMockUser
     void getMentorDetailApi_Failure_NotFound() throws Exception {

--- a/src/test/java/app/sigorotalk/backend/domain/auth/AuthControllerTest.java
+++ b/src/test/java/app/sigorotalk/backend/domain/auth/AuthControllerTest.java
@@ -1,4 +1,4 @@
-package app.sigorotalk.backend.config.auth;
+package app.sigorotalk.backend.domain.auth;
 
 
 import app.sigorotalk.backend.domain.auth.dto.LoginRequestDto;

--- a/src/test/java/app/sigorotalk/backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/app/sigorotalk/backend/domain/auth/AuthServiceTest.java
@@ -1,9 +1,7 @@
-package app.sigorotalk.backend.config.auth;
+package app.sigorotalk.backend.domain.auth;
 
 import app.sigorotalk.backend.common.exception.BusinessException;
 import app.sigorotalk.backend.config.jwt.JwtTokenProvider;
-import app.sigorotalk.backend.domain.auth.AuthErrorCode;
-import app.sigorotalk.backend.domain.auth.AuthService;
 import app.sigorotalk.backend.domain.auth.dto.LoginResponseDto;
 import app.sigorotalk.backend.domain.auth.dto.TokenRefreshResponseDto;
 import app.sigorotalk.backend.domain.user.User;

--- a/src/test/java/app/sigorotalk/backend/domain/auth/JwtTokenProviderTest.java
+++ b/src/test/java/app/sigorotalk/backend/domain/auth/JwtTokenProviderTest.java
@@ -1,4 +1,4 @@
-package app.sigorotalk.backend.config.auth;
+package app.sigorotalk.backend.domain.auth;
 
 import app.sigorotalk.backend.config.jwt.JwtTokenProvider;
 import io.jsonwebtoken.security.SecurityException;

--- a/src/test/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatApplicationRepositoryTest.java
+++ b/src/test/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatApplicationRepositoryTest.java
@@ -1,8 +1,6 @@
-package app.sigorotalk.backend.config.coffeechat;
+package app.sigorotalk.backend.domain.coffeechat;
 
 import app.sigorotalk.backend.config.QueryDslConfig;
-import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplication;
-import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplicationRepository;
 import app.sigorotalk.backend.domain.mentor.Mentor;
 import app.sigorotalk.backend.domain.mentor.MentorRepository;
 import app.sigorotalk.backend.domain.user.User;

--- a/src/test/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatApplicationTest.java
+++ b/src/test/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatApplicationTest.java
@@ -1,7 +1,6 @@
-package app.sigorotalk.backend.config.coffeechat;
+package app.sigorotalk.backend.domain.coffeechat;
 
 import app.sigorotalk.backend.common.exception.BusinessException;
-import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplication;
 import app.sigorotalk.backend.domain.mentor.Mentor;
 import app.sigorotalk.backend.domain.user.User;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatServiceTest.java
+++ b/src/test/java/app/sigorotalk/backend/domain/coffeechat/CoffeeChatServiceTest.java
@@ -1,10 +1,6 @@
-package app.sigorotalk.backend.config.coffeechat;
+package app.sigorotalk.backend.domain.coffeechat;
 
 import app.sigorotalk.backend.common.exception.BusinessException;
-import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplication;
-import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplicationRepository;
-import app.sigorotalk.backend.domain.coffeechat.CoffeeChatErrorCode;
-import app.sigorotalk.backend.domain.coffeechat.CoffeeChatService;
 import app.sigorotalk.backend.domain.coffeechat.dto.CoffeeChatApplyRequestDto;
 import app.sigorotalk.backend.domain.coffeechat.dto.CoffeeChatApplyResponseDto;
 import app.sigorotalk.backend.domain.coffeechat.dto.MyChatListResponseDto;

--- a/src/test/java/app/sigorotalk/backend/domain/mentor/MentorControllerTest.java
+++ b/src/test/java/app/sigorotalk/backend/domain/mentor/MentorControllerTest.java
@@ -1,7 +1,5 @@
-package app.sigorotalk.backend.config.mentor;
+package app.sigorotalk.backend.domain.mentor;
 
-import app.sigorotalk.backend.domain.mentor.Mentor;
-import app.sigorotalk.backend.domain.mentor.MentorRepository;
 import app.sigorotalk.backend.domain.user.User;
 import app.sigorotalk.backend.domain.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/app/sigorotalk/backend/domain/mentor/MentorServiceTest.java
+++ b/src/test/java/app/sigorotalk/backend/domain/mentor/MentorServiceTest.java
@@ -1,9 +1,6 @@
-package app.sigorotalk.backend.config.mentor;
+package app.sigorotalk.backend.domain.mentor;
 
 import app.sigorotalk.backend.common.exception.BusinessException;
-import app.sigorotalk.backend.domain.mentor.Mentor;
-import app.sigorotalk.backend.domain.mentor.MentorRepository;
-import app.sigorotalk.backend.domain.mentor.MentorService;
 import app.sigorotalk.backend.domain.review.Review;
 import app.sigorotalk.backend.domain.review.ReviewRepository;
 import app.sigorotalk.backend.domain.user.User;

--- a/src/test/java/app/sigorotalk/backend/domain/review/ReviewControllerTest.java
+++ b/src/test/java/app/sigorotalk/backend/domain/review/ReviewControllerTest.java
@@ -1,0 +1,110 @@
+package app.sigorotalk.backend.domain.review;
+
+
+import app.sigorotalk.backend.config.jwt.JwtTokenProvider;
+import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplication;
+import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplicationRepository;
+import app.sigorotalk.backend.domain.mentor.Mentor;
+import app.sigorotalk.backend.domain.mentor.MentorRepository;
+import app.sigorotalk.backend.domain.review.dto.ReviewRequestDto;
+import app.sigorotalk.backend.domain.user.User;
+import app.sigorotalk.backend.domain.user.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+// @Transactional 제거!
+class ReviewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private MentorRepository mentorRepository;
+    @Autowired
+    private CoffeeChatApplicationRepository coffeeChatApplicationRepository;
+    @Autowired
+    private ReviewRepository reviewRepository;
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    private User mentee;
+    private Mentor mentor;
+    private CoffeeChatApplication completedChat;
+
+    @BeforeEach
+    void setUp() {
+        mentee = userRepository.save(User.builder().email("mentee@test.com").name("테스트멘티").password("pw").role(User.Role.ROLE_USER).build());
+        User mentorUser = userRepository.save(User.builder().email("mentor@test.com").name("테스트멘토").password("pw").role(User.Role.ROLE_MENTOR).build());
+        mentor = mentorRepository.save(Mentor.builder().user(mentorUser).reviewCount(0).averageRating(BigDecimal.ZERO).build());
+        completedChat = coffeeChatApplicationRepository.save(CoffeeChatApplication.builder().mentor(mentor).mentee(mentee).status(CoffeeChatApplication.Status.COMPLETED).build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        reviewRepository.deleteAllInBatch();
+        coffeeChatApplicationRepository.deleteAllInBatch();
+        mentorRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("성공: 멘티가 완료된 커피챗에 리뷰를 작성하면, 비동기 처리가 완료된 후 멘토 평점이 정상적으로 업데이트된다.")
+    void createReview_Async_E2E_Success() throws Exception {
+        // given
+        Authentication authentication = new UsernamePasswordAuthenticationToken(mentee.getId(), null, Collections.singletonList(new SimpleGrantedAuthority(mentee.getRole().toString())));
+        String accessToken = jwtTokenProvider.createAccessToken(authentication);
+        ReviewRequestDto requestDto = createReviewRequestDto(completedChat.getId(), 5, "정말 유익한 시간이었습니다!");
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // when
+        mockMvc.perform(post("/api/v1/reviews")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andDo(print());
+
+        // then
+        await().atMost(5, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+            Mentor updatedMentor = mentorRepository.findById(mentor.getId())
+                    .orElseThrow(() -> new AssertionError("멘토를 찾을 수 없습니다.")); // 에러 발생 시 더 명확한 메시지
+            assertThat(updatedMentor.getReviewCount()).isEqualTo(1);
+            assertThat(updatedMentor.getAverageRating()).isEqualByComparingTo(new BigDecimal("5.0"));
+        });
+    }
+
+    private ReviewRequestDto createReviewRequestDto(Long chatId, int rating, String comment) {
+        ReviewRequestDto dto = new ReviewRequestDto();
+        ReflectionTestUtils.setField(dto, "chatId", chatId);
+        ReflectionTestUtils.setField(dto, "rating", rating);
+        ReflectionTestUtils.setField(dto, "comment", comment);
+        return dto;
+    }
+}

--- a/src/test/java/app/sigorotalk/backend/domain/review/ReviewServiceTest.java
+++ b/src/test/java/app/sigorotalk/backend/domain/review/ReviewServiceTest.java
@@ -1,0 +1,122 @@
+package app.sigorotalk.backend.domain.review;
+
+import app.sigorotalk.backend.common.exception.BusinessException;
+import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplication;
+import app.sigorotalk.backend.domain.coffeechat.CoffeeChatApplicationRepository;
+import app.sigorotalk.backend.domain.mentor.Mentor;
+import app.sigorotalk.backend.domain.review.dto.ReviewRequestDto;
+import app.sigorotalk.backend.domain.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+    @InjectMocks
+    private ReviewService reviewService;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+    @Mock
+    private CoffeeChatApplicationRepository coffeeChatApplicationRepository;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private User mentee;
+    private Mentor mentor;
+    private CoffeeChatApplication completedChat;
+
+    @BeforeEach
+    void setUp() {
+        mentee = User.builder().id(1L).build();
+        mentor = Mentor.builder().id(10L).build();
+        completedChat = CoffeeChatApplication.builder()
+                .id(100L)
+                .mentee(mentee)
+                .mentor(mentor)
+                .status(CoffeeChatApplication.Status.COMPLETED)
+                .build();
+    }
+
+    @Test
+    @DisplayName("성공: 리뷰 작성 시, 리뷰 저장 및 이벤트 발행이 정상적으로 호출된다.")
+    void createReview_Success() {
+        // given
+        ReviewRequestDto requestDto = createReviewRequestDto(completedChat.getId(), 5, "최고의 멘토링!");
+        when(reviewRepository.existsByCoffeeChatApplicationId(completedChat.getId())).thenReturn(false);
+        when(coffeeChatApplicationRepository.findById(completedChat.getId())).thenReturn(Optional.of(completedChat));
+
+        // when
+        reviewService.createReview(requestDto, mentee.getId());
+
+        // then
+        verify(reviewRepository, times(1)).save(any(Review.class));
+        verify(eventPublisher, times(1)).publishEvent(any(ReviewCreatedEvent.class));
+    }
+
+    @Test
+    @DisplayName("실패: 이미 리뷰를 작성한 커피챗에 다시 작성 시도 시 예외가 발생한다.")
+    void createReview_Failure_AlreadyExists() {
+        // given
+        ReviewRequestDto requestDto = createReviewRequestDto(completedChat.getId(), 5, "또 쓸래요");
+        when(reviewRepository.existsByCoffeeChatApplicationId(completedChat.getId())).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.createReview(requestDto, mentee.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("리뷰는 한 번만 작성할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("실패: 완료되지 않은 커피챗에 리뷰 작성 시도 시 예외가 발생한다.")
+    void createReview_Failure_InvalidStatus() {
+        // given
+        // 테스트 시나리오에 맞게 'ACCEPTED' 상태의 객체를 새로 생성
+        CoffeeChatApplication acceptedChat = CoffeeChatApplication.builder().status(CoffeeChatApplication.Status.ACCEPTED).build();
+        ReviewRequestDto requestDto = createReviewRequestDto(acceptedChat.getId(), 5, "미리 쓸래요");
+        when(reviewRepository.existsByCoffeeChatApplicationId(acceptedChat.getId())).thenReturn(false);
+        when(coffeeChatApplicationRepository.findById(acceptedChat.getId())).thenReturn(Optional.of(acceptedChat));
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.createReview(requestDto, mentee.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("완료된 커피챗에만 리뷰를 작성할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("실패: 권한이 없는 사용자(멘토 등)가 리뷰 작성 시도 시 예외가 발생한다.")
+    void createReview_Failure_NoAuthority() {
+        // given
+        Long otherUserId = 99L; // 다른 사용자 ID
+        ReviewRequestDto requestDto = createReviewRequestDto(completedChat.getId(), 5, "내가 쓸래요");
+        when(reviewRepository.existsByCoffeeChatApplicationId(completedChat.getId())).thenReturn(false);
+        when(coffeeChatApplicationRepository.findById(completedChat.getId())).thenReturn(Optional.of(completedChat));
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.createReview(requestDto, otherUserId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("리뷰를 작성할 권한이 없습니다.");
+    }
+
+    // 테스트용 DTO 생성을 위한 헬퍼 메서드
+    private ReviewRequestDto createReviewRequestDto(Long chatId, int rating, String comment) {
+        ReviewRequestDto dto = new ReviewRequestDto();
+        ReflectionTestUtils.setField(dto, "chatId", chatId);
+        ReflectionTestUtils.setField(dto, "rating", rating);
+        ReflectionTestUtils.setField(dto, "comment", comment);
+        return dto;
+    }
+}

--- a/src/test/java/app/sigorotalk/backend/domain/user/CustomUserDetailServiceTest.java
+++ b/src/test/java/app/sigorotalk/backend/domain/user/CustomUserDetailServiceTest.java
@@ -1,8 +1,5 @@
-package app.sigorotalk.backend.config.user;
+package app.sigorotalk.backend.domain.user;
 
-import app.sigorotalk.backend.domain.user.CustomUserDetailService;
-import app.sigorotalk.backend.domain.user.User;
-import app.sigorotalk.backend.domain.user.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/app/sigorotalk/backend/domain/user/UserServiceTest.java
+++ b/src/test/java/app/sigorotalk/backend/domain/user/UserServiceTest.java
@@ -1,9 +1,6 @@
-package app.sigorotalk.backend.config.user;
+package app.sigorotalk.backend.domain.user;
 
 import app.sigorotalk.backend.common.exception.BusinessException;
-import app.sigorotalk.backend.domain.user.User;
-import app.sigorotalk.backend.domain.user.UserRepository;
-import app.sigorotalk.backend.domain.user.UserService;
 import app.sigorotalk.backend.domain.user.dto.SignUpRequestDto;
 import app.sigorotalk.backend.domain.user.dto.UserResponseDto;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
### **개요 (Overview)** 📜

이번 PR은 사용자의 핵심 경험을 완성하는 두 가지 주요 기능, **멘토 동적 필터링**과 **리뷰 작성** 기능을 추가합니다.

- 사용자는 이제 원하는 조건으로 멘토를 검색할 수 있습니다.
    
- 멘티는 커피챗이 완료된 후 멘토에게 리뷰를 남겨 피드백을 제공하고, 이는 멘토의 평점에 비동기적으로 반영됩니다.
    

### **주요 기능 및 변경 사항 (Key Features & Changes)** ✨

#### **1. 멘토 기능 확장: 동적 필터링 (QueryDSL)**

- 멘토 목록 조회 API(`GET /api/v1/mentors`)에 **지역(region)**과 **전문분야(expertise)**를 기준으로 한 동적 필터링 기능을 추가했습니다.
    
- `build.gradle`에 QueryDSL 의존성을 추가하고, `MentorRepositoryImpl`을 통해 타입-세이프(Type-safe)하게 동적 쿼리를 구현하여 안정성을 높였습니다.
    

#### **2. 리뷰 기능 신규 구현 (Event-Driven Architecture)**

- **리뷰 작성 API (`POST /api/v1/reviews`)**: `COMPLETED` 상태의 커피챗에 대해 멘티만 리뷰를 작성할 수 있도록 강력한 검증 로직을 포함하여 구현했습니다.
    
- **비동기 평점 업데이트**: 리뷰가 생성되면 `ReviewCreatedEvent`를 발행하고, `@EventListener`와 `@Async`를 통해 별도의 스레드에서 멘토의 평점을 업데이트하도록 설계했습니다. 이를 통해 API 응답 시간을 단축하고 도메인 간의 결합도를 낮췄습니다.
    
- **테스트 전략 강화**: 비동기 트랜잭션으로 인해 발생하는 변덕스러운 테스트(Flaky Test) 문제를 해결하기 위해, 테스트 환경의 트랜잭션을 분리하고 `Awaitility`를 도입하여 End-to-End 테스트의 신뢰도를 확보했습니다.
    

### **리뷰어에게 (To Reviewers)** 👀

- **`MentorRepositoryImpl`**: QueryDSL을 활용한 동적 쿼리 생성 로직이 비즈니스 요구사항에 맞게 잘 구현되었는지 확인 부탁드립니다.
    
- **`ReviewService` & `MentorService`**: 두 서비스가 `ApplicationEventPublisher`를 통해 어떻게 의존성을 해소하고 비동기적으로 상호작용하는지 중점적으로 봐주시면 감사하겠습니다.
    
- **`ReviewControllerTest`**: `Awaitility`를 사용하여 비동기 로직을 테스트하는 방식에 대해 함께 검토해 보면 좋을 것 같습니다.