### PR TITLE
feat(order): 주문 처리 기능 구현 및 시스템 안정성 개선

### DIFF
--- a/src/main/java/app/sigorotalk/backend/config/SecurityConfig.java
+++ b/src/main/java/app/sigorotalk/backend/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/actuator/prometheus").permitAll() // 모니터링 로그 수집 엔드포인트 허용!
                         .requestMatchers(SWAGGER_URLS).permitAll()
-                        .requestMatchers("/api/v1/auth/**", "/api/v1/users", "/login").permitAll() // 로그인, 회원가입은 허용
+                        .requestMatchers("/api/auth/**", "/api/users", "/login").permitAll() // 로그인, 회원가입은 허용
                         .anyRequest().authenticated() // 나머지는 인증 필요
                 )
 

--- a/src/main/java/app/sigorotalk/backend/domain/auth/AuthController.java
+++ b/src/main/java/app/sigorotalk/backend/domain/auth/AuthController.java
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/src/main/java/app/sigorotalk/backend/domain/order/Order.java
+++ b/src/main/java/app/sigorotalk/backend/domain/order/Order.java
@@ -2,22 +2,16 @@ package app.sigorotalk.backend.domain.order;
 import app.sigorotalk.backend.common.entity.BaseTimeEntity;
 import app.sigorotalk.backend.domain.order_item.OrderItem;
 import app.sigorotalk.backend.domain.payment.Payment;
+import app.sigorotalk.backend.domain.product.Product;
 import app.sigorotalk.backend.domain.user.User;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -25,26 +19,27 @@ import lombok.Setter;
 @Entity
 @Table(name = "orders")
 @Getter @Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order extends BaseTimeEntity{
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user; // 구매자
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "order_status")
-    private String orderStatus;
+    private OrderStatus orderStatus;
 
     @Column(name = "total_price")
     private BigDecimal totalPrice;
 
     private String address;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "delivery_status")
-    private String deliveryStatus;
+    private DeliveryStatus deliveryStatus;
 
     @Column(name = "shipped_at")
     private LocalDateTime shippedAt;
@@ -57,4 +52,48 @@ public class Order extends BaseTimeEntity{
 
     @OneToOne(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private Payment payment;
+
+    public enum OrderStatus {
+        PAYMENT_COMPLETED,  // 결제 완료
+        ORDER_CANCELED      // 주문 취소
+    }
+
+    public enum DeliveryStatus {
+        PREPARING,          // 배송 준비중
+        SHIPPED,            // 배송중
+        DELIVERED           // 배송 완료
+    }
+
+    //== 생성 메서드 ==//
+    public static Order createOrder(User user, Product product) {
+        final int QUANTITY = 1; // MVP에서는 수량을 1로 고정
+
+        Order order = new Order();
+        order.setUser(user);
+        order.setOrderStatus(OrderStatus.PAYMENT_COMPLETED);
+        order.setDeliveryStatus(DeliveryStatus.PREPARING);
+
+        // 단가 * 수량(1) 으로 총액 계산
+        order.setTotalPrice(product.getPrice());
+
+        // 주문 상품 생성
+        OrderItem orderItem = OrderItem.createOrderItem(product, product.getPrice(), QUANTITY);
+        order.addOrderItem(orderItem);
+
+        // 상품 재고 감소
+        product.decreaseStock(QUANTITY);
+
+        return order;
+    }
+
+    //== 연관관계 편의 메서드 ==//
+    public void addOrderItem(OrderItem orderItem) {
+        orderItems.add(orderItem);
+        orderItem.setOrder(this);
+    }
+
+    public void setPayment(Payment payment) {
+        this.payment = payment;
+        payment.setOrder(this);
+    }
 }

--- a/src/main/java/app/sigorotalk/backend/domain/order/OrderController.java
+++ b/src/main/java/app/sigorotalk/backend/domain/order/OrderController.java
@@ -1,0 +1,42 @@
+package app.sigorotalk.backend.domain.order;
+
+
+import app.sigorotalk.backend.common.response.ApiResponse;
+import app.sigorotalk.backend.domain.order.dto.OrderRequestDto;
+import app.sigorotalk.backend.domain.order.dto.OrderResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<OrderResponseDto>> orderProduct(
+            @Valid @RequestBody OrderRequestDto requestDto,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        // 1. 현재 로그인한 사용자의 정보를 SecurityContext에서 가져옴
+        // (CustomUserDetailService에서 Principal을 userId로 설정했음)
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        // 2. 서비스 로직 호출하여 주문 처리
+        OrderResponseDto responseDto = orderService.processOrder(userId, requestDto);
+
+        // 3. 성공 응답 반환 (201 Created)
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(responseDto));
+    }
+}

--- a/src/main/java/app/sigorotalk/backend/domain/order/OrderRepository.java
+++ b/src/main/java/app/sigorotalk/backend/domain/order/OrderRepository.java
@@ -1,0 +1,6 @@
+package app.sigorotalk.backend.domain.order;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/app/sigorotalk/backend/domain/order/OrderService.java
+++ b/src/main/java/app/sigorotalk/backend/domain/order/OrderService.java
@@ -1,0 +1,56 @@
+package app.sigorotalk.backend.domain.order;
+
+import app.sigorotalk.backend.common.exception.BusinessException;
+import app.sigorotalk.backend.domain.order.dto.OrderRequestDto;
+import app.sigorotalk.backend.domain.order.dto.OrderResponseDto;
+import app.sigorotalk.backend.domain.payment.Payment;
+import app.sigorotalk.backend.domain.product.Product;
+import app.sigorotalk.backend.domain.product.ProductErrorCode;
+import app.sigorotalk.backend.domain.product.ProductRepository;
+import app.sigorotalk.backend.domain.user.User;
+import app.sigorotalk.backend.domain.user.UserErrorCode;
+import app.sigorotalk.backend.domain.user.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
+    private final ProductRepository productRepository;
+
+    /**
+     * 주문 및 결제 처리 (트랜잭션으로 관리)
+     *
+     * @param userId     주문하는 사용자의 ID
+     * @param requestDto 주문 요청 정보 (productId)
+     * @return 주문 결과 정보
+     */
+    @Transactional
+    public OrderResponseDto processOrder(Long userId, OrderRequestDto requestDto) {
+        // 1. 사용자 및 상품 정보 조회
+        // (상품은 동시성 제어를 위해 비관적 락을 걸어 안전하게 조회)
+        User user = userRepository.findById(userId).orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        Product product = productRepository.findByIdWithPessimisticLock(requestDto.getProductId()).orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        // 2. 주문 생성 (엔티티 내부의 생성 메서드 호출)
+        Order order = Order.createOrder(user, product);
+
+        // 3. 결제 정보 생성 (결제 시뮬레이션)
+        Payment payment = new Payment();
+        payment.setFinalAmount(order.getTotalPrice());
+        payment.setMethod("SIMULATED_PAYMENT");
+        order.setPayment(payment);
+
+        // 4. 주문 저장 (Cascade 설정으로 OrderItem, Payment가 함께 저장됨)
+        Order savedOrder = orderRepository.save(order);
+
+        // 5. 결과 DTO 반환
+        return new OrderResponseDto(savedOrder.getId(), savedOrder.getOrderStatus().name());
+    }
+}

--- a/src/main/java/app/sigorotalk/backend/domain/order/OrderService.java
+++ b/src/main/java/app/sigorotalk/backend/domain/order/OrderService.java
@@ -11,7 +11,7 @@ import app.sigorotalk.backend.domain.user.User;
 import app.sigorotalk.backend.domain.user.UserErrorCode;
 import app.sigorotalk.backend.domain.user.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/app/sigorotalk/backend/domain/order/OrderService.java
+++ b/src/main/java/app/sigorotalk/backend/domain/order/OrderService.java
@@ -41,9 +41,7 @@ public class OrderService {
         Order order = Order.createOrder(user, product);
 
         // 3. 결제 정보 생성 (결제 시뮬레이션)
-        Payment payment = new Payment();
-        payment.setFinalAmount(order.getTotalPrice());
-        payment.setMethod("SIMULATED_PAYMENT");
+        Payment payment = Payment.createPayment(order.getTotalPrice(), "SIMULATED_PAYMENT");
         order.setPayment(payment);
 
         // 4. 주문 저장 (Cascade 설정으로 OrderItem, Payment가 함께 저장됨)

--- a/src/main/java/app/sigorotalk/backend/domain/order/OrderService.java
+++ b/src/main/java/app/sigorotalk/backend/domain/order/OrderService.java
@@ -10,7 +10,6 @@ import app.sigorotalk.backend.domain.product.ProductRepository;
 import app.sigorotalk.backend.domain.user.User;
 import app.sigorotalk.backend.domain.user.UserErrorCode;
 import app.sigorotalk.backend.domain.user.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/app/sigorotalk/backend/domain/order/dto/OrderRequestDto.java
+++ b/src/main/java/app/sigorotalk/backend/domain/order/dto/OrderRequestDto.java
@@ -1,0 +1,12 @@
+package app.sigorotalk.backend.domain.order.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class OrderRequestDto {
+
+    @NotNull(message = "상품 ID는 필수입니다.")
+    private Long productId;
+
+}

--- a/src/main/java/app/sigorotalk/backend/domain/order/dto/OrderResponseDto.java
+++ b/src/main/java/app/sigorotalk/backend/domain/order/dto/OrderResponseDto.java
@@ -1,0 +1,17 @@
+package app.sigorotalk.backend.domain.order.dto;
+
+import lombok.Getter;
+
+@Getter
+public class OrderResponseDto {
+
+    private final Long orderId;
+    private final String orderStatus;
+    private final String message;
+
+    public OrderResponseDto(Long orderId, String orderStatus) {
+        this.orderId = orderId;
+        this.orderStatus = orderStatus;
+        this.message = "주문 및 결제가 성공적으로 완료되었습니다.";
+    }
+}

--- a/src/main/java/app/sigorotalk/backend/domain/order_item/OrderItem.java
+++ b/src/main/java/app/sigorotalk/backend/domain/order_item/OrderItem.java
@@ -7,7 +7,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.*;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+
 import java.math.BigDecimal;
+
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -16,18 +19,18 @@ import lombok.Setter;
 @Table(name = "order_items")
 @Getter
 @Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderItem extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id")
     private Order order;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
 
@@ -35,4 +38,13 @@ public class OrderItem extends BaseTimeEntity {
 
     @Column(name = "unit_price")
     private BigDecimal unitPrice;
+
+    //== 생성 메서드 ==//
+    public static OrderItem createOrderItem(Product product, BigDecimal unitPrice, int quantity) {
+        OrderItem orderItem = new OrderItem();
+        orderItem.setProduct(product);
+        orderItem.setUnitPrice(unitPrice);
+        orderItem.setQuantity(quantity);
+        return orderItem;
+    }
 }

--- a/src/main/java/app/sigorotalk/backend/domain/order_item/OrderItemRepository.java
+++ b/src/main/java/app/sigorotalk/backend/domain/order_item/OrderItemRepository.java
@@ -1,0 +1,6 @@
+package app.sigorotalk.backend.domain.order_item;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+}

--- a/src/main/java/app/sigorotalk/backend/domain/product/Product.java
+++ b/src/main/java/app/sigorotalk/backend/domain/product/Product.java
@@ -1,5 +1,6 @@
 package app.sigorotalk.backend.domain.product;
 import app.sigorotalk.backend.common.entity.BaseTimeEntity;
+import app.sigorotalk.backend.common.exception.BusinessException;
 import app.sigorotalk.backend.domain.diarie.Diary;
 import app.sigorotalk.backend.domain.farm_project.FarmProject;
 import app.sigorotalk.backend.domain.order_item.OrderItem;
@@ -54,4 +55,12 @@ public class Product extends BaseTimeEntity{
 
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderItem> orderItems = new ArrayList<>();
+
+    public void decreaseStock(int quantity) {
+        int restStock = this.stock - quantity;
+        if (restStock < 0) {
+            throw new BusinessException(ProductErrorCode.NOT_ENOUGH_STOCK); // 재고 부족 예외 (별도 정의 필요)
+        }
+        this.stock = restStock;
+    }
 }

--- a/src/main/java/app/sigorotalk/backend/domain/product/ProductErrorCode.java
+++ b/src/main/java/app/sigorotalk/backend/domain/product/ProductErrorCode.java
@@ -1,0 +1,17 @@
+package app.sigorotalk.backend.domain.product;
+
+import app.sigorotalk.backend.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductErrorCode implements ErrorCode {
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 상품을 찾을 수 없습니다."),
+    NOT_ENOUGH_STOCK(HttpStatus.BAD_REQUEST, 400, "상품의 재고가 부족합니다.");
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/app/sigorotalk/backend/domain/product/ProductRepository.java
+++ b/src/main/java/app/sigorotalk/backend/domain/product/ProductRepository.java
@@ -1,0 +1,17 @@
+package app.sigorotalk.backend.domain.product;
+
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    // 재고 동시성 문제를 해결하기 위해 비관적 락(Pessimistic Lock) 사용
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Product p where p.id = :id")
+    Optional<Product> findByIdWithPessimisticLock(Long id);
+
+}

--- a/src/main/java/app/sigorotalk/backend/domain/user/UserController.java
+++ b/src/main/java/app/sigorotalk/backend/domain/user/UserController.java
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/users")
+@RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
 


### PR DESCRIPTION
이번 PR은 사용자가 상품을 선택하여 결제하고 주문을 완료하는 핵심 비즈니스 로직을 구현합니다. 더불어, 전체 시스템의 안정성과 유지보수성을 높이기 위한 리팩토링 및 버그 수정 작업을 포함합니다.

### 주요 변경 사항

#### 1. 🚀 주문 기능 핵심 구현

-   **주문 처리 API 엔드포인트(`POST /api/orders`)를 신규 개발**했습니다.
-   Service 계층에 **`@Transactional`**을 적용하여, 주문 생성, 재고 차감, 결제 정보 생성이 **원자적으로 처리**되도록 보장합니다.
-   **동시성 제어**: 여러 사용자가 동시에 주문할 때 발생할 수 있는 데이터 정합성 문제를 해결하기 위해, 재고 차감 로직에 **비관적 락(`Pessimistic Lock`)**을 적용했습니다.
-   **객체지향 설계**: `Order.createOrder()`와 같은 정적 팩토리 메서드를 도입하여, 도메인 엔티티가 스스로 상태와 행위를 관리하도록 설계했습니다.

#### 2. 🛠️ 예외 처리 및 엔티티 설계 리팩토링

-   **예외 처리 개선**: 사용자/상품 조회 실패 시, 프로젝트의 표준 방식인 `BusinessException`과 `ErrorCode`를 사용하도록 리팩토링하여 API 응답의 명확성을 높였습니다.
-   **엔티티 안정성 강화**:
    -   `Order`의 상태(`orderStatus`, `deliveryStatus`)를 `String`에서 **`Enum` 타입으로 변경**하여 타입 안정성을 확보했습니다.
    -   엔티티의 기본 생성자를 **`protected`로 제한**하여, 의도된 방식으로만 객체가 생성되도록 강제했습니다.

#### 3. 🐛 인증 버그 수정

-   **회원가입(`POST /api/v1/users`) 시 401 에러가 발생하던 문제를 해결**했습니다.
-   `UserController`의 API 경로와 `SecurityConfig`에 정의된 허용 경로가 `v1` 버전 접두사 차이로 불일치했던 문제를 수정했습니다.

### ✅ 테스트 방법

1.  **회원가입 및 로그인**
    -   `POST /api/v1/users` 로 회원가입을 요청하여 `201 Created` 응답을 확인합니다.
    -   `POST /api/v1/auth/login` 로 로그인하여 `accessToken`을 발급받습니다.

2.  **주문 성공 테스트**
    -   `POST /api/v1/orders` 로 요청을 보냅니다.
    -   **Headers**: `Authorization`에 `Bearer <accessToken>`을 포함합니다.
    -   **Body**: `{"productId": 1}` (DB에 존재하는 상품 ID)
    -   **결과**: `201 Created` 응답과 함께 주문 정보가 반환되는지 확인합니다. DB에서 해당 상품의 재고가 1 감소했는지 확인합니다.

3.  **재고 부족 테스트**
    -   DB에서 특정 상품의 재고를 `0`으로 수정한 후, 위 2번과 동일한 주문을 요청합니다.
    -   **결과**: `400 Bad Request` 상태 코드와 함께 "상품의 재고가 부족합니다." 메시지가 반환되는지 확인합니다.
